### PR TITLE
fear:新建项目新增封面，视频库有项目分组

### DIFF
--- a/api/novel.py
+++ b/api/novel.py
@@ -30,7 +30,7 @@ async def patch_novel(novel_id: int, novel: NovelPatch):
     "", summary="获取小说/剧本列表", response_model=ResponseSchema[PaginationResponse[NovelBriefOut]]
 )
 async def get_novel_list(params: QueryParams = Depends(get_list_params)):
-    novels = await novel_controller.list(params, NovelBriefOut)
+    novels = await novel_controller.list(params, NovelBriefOut, search_fields=['name', 'author'])
     return ResponseSchema(data=novels)
 
 

--- a/api/video.py
+++ b/api/video.py
@@ -66,4 +66,7 @@ async def get_chapter_videos(chapter_id: int):
     videos = await video_controller.get_chapter_videos(chapter_id)
     return ResponseSchema(data=videos)
 
-
+@router.get("/novel/{novel_id}", summary="获取小说下的所有视频")
+async def get_novel_videos(novel_id: int):
+    videos = await video_controller.get_novel_videos(novel_id)
+    return ResponseSchema(data=videos)

--- a/controllers/video.py
+++ b/controllers/video.py
@@ -205,6 +205,36 @@ class VideoController(CRUDBase[Video, dict, dict]):
 
         return result
 
+    async def get_novel_videos(self, novel_id: int) -> list[dict]:
+        """获取小说下所有视频。
+
+        Args:
+            novel_id: 小说 ID
+
+        Returns:
+            [
+                {
+                    "id": 10,
+                    "url": "/media/videos/10.mp4",
+                    "status": 3,
+                    "model_type": 4
+                },
+                ...
+            ]
+        """
+        videos = await Video.filter(
+            scene__chapter__novel_id=novel_id
+        ).order_by("-created_at")
+        return [
+        {
+            "id": video.id,
+            "url": video.url,
+            "status": video.status,
+            "model_type": video.model_type
+        }
+        for video in videos
+    ]
+
     async def merge_chapter_videos(self, chapter_id: int) -> dict:
         """合并章节下所有已完成的视频。
 

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -25,6 +25,7 @@ const App: React.FC = () => {
             <Route path="/" element={<Dashboard />} />
             <Route path="/novel/:id" element={<NovelDetail />} />
             <Route path="/novel/:novelId/chapter/:chapterId/step/:stepId" element={<WorkflowLayout />} />
+            <Route path="/videos/novel/:id" element={<VideosPage />} />
             <Route path="/videos" element={<VideosPage />} />
             <Route path="/config" element={<ConfigPage />} />
           </Routes>

--- a/web/globals.css
+++ b/web/globals.css
@@ -1,9 +1,9 @@
+/* Distinctive Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Noto+Serif+SC:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Distinctive Fonts */
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Noto+Serif+SC:wght@400;600;700&display=swap');
 
 @layer base {
   :root {

--- a/web/pages/Dashboard.tsx
+++ b/web/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { BookOpen, Plus, Trash2, Sparkles, ImagePlus, X } from 'lucide-react'
 import { toast } from 'sonner'
@@ -17,31 +17,51 @@ import { Textarea } from '@/components/ui/textarea'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { api } from '@/services/api'
-import type { Novel, Pagination as PaginationType } from '@/types'
-import { Pagination } from '@/components/Pagination'
+import type { Novel, Pagination } from '@/types'
 
 export const Dashboard = () => {
   const [novels, setNovels] = useState<Novel[]>([])
   const [loading, setLoading] = useState(true)
-  const [pagination, setPagination] = useState<PaginationType | null>(null)
+  const [pagination, setPagination] = useState<Pagination | null>(null)
   const [page, setPage] = useState(1)
   const [dialogOpen, setDialogOpen] = useState(false)
   const [creating, setCreating] = useState(false)
-  const [form, setForm] = useState({ name: '', author: '', description: '' })
-  const [coverFile, setCoverFile] = useState<File | null>(null)
+  const [form, setForm] = useState({ name: '', author: '', description: '', cover: '' })
+  const [uploadingCover, setUploadingCover] = useState(false)
   const [coverPreview, setCoverPreview] = useState<string | null>(null)
+  const uploadRef = useRef<HTMLInputElement>(null)
 
-  const handleCoverChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleCoverChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
-    setCoverFile(file)
+    
+    // 显示预览
     setCoverPreview(URL.createObjectURL(file))
+    
+    // 上传文件
+    setUploadingCover(true)
+    try {
+      const res = await api.uploadFiles([file])
+      const uploaded = res.data.files[0]
+      setForm((f) => ({ ...f, cover: `/media/${uploaded.filename}` }))
+    } catch (err: any) {
+      toast.error(err.message || '上传失败')
+      // 上传失败时清除预览
+      clearCover()
+    } finally {
+      setUploadingCover(false)
+    }
+    
+    // 清空 input 值，允许重新选择同一文件
+    e.target.value = ''
   }
 
   const clearCover = () => {
-    setCoverFile(null)
-    if (coverPreview) URL.revokeObjectURL(coverPreview)
-    setCoverPreview(null)
+    setForm((f) => ({ ...f, cover: '' }))
+    if (coverPreview) {
+      URL.revokeObjectURL(coverPreview)
+      setCoverPreview(null)
+    }
   }
 
   const fetchNovels = async (p: number = page) => {
@@ -65,21 +85,15 @@ export const Dashboard = () => {
     if (!form.name.trim()) return
     try {
       setCreating(true)
-      let cover: string | undefined
-      if (coverFile) {
-        const uploadRes = await api.uploadFiles([coverFile])
-        const uploaded = uploadRes.data.files[0]
-        cover = `/media/${uploaded.filename}`
-      }
       await api.createNovel({
         name: form.name.trim(),
         author: form.author.trim() || undefined,
         description: form.description.trim() || undefined,
-        cover,
+        cover: form.cover || undefined,
       })
       toast.success('项目创建成功')
       setDialogOpen(false)
-      setForm({ name: '', author: '', description: '' })
+      setForm({ name: '', author: '', description: '', cover: '' })
       clearCover()
       await fetchNovels(page)
     } catch (err: any) {
@@ -216,7 +230,27 @@ export const Dashboard = () => {
 
         {/* Pagination */}
         {pagination && pagination.pages > 1 && (
-          <Pagination current={page} total={pagination.pages} onChange={setPage} />
+          <div className="flex items-center justify-center gap-4 pt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+            >
+              上一页
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              第 {page} / {pagination.pages} 页
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.min(pagination!.pages, p + 1))}
+              disabled={page >= pagination.pages}
+            >
+              下一页
+            </Button>
+          </div>
         )}
         </>
       )}
@@ -231,26 +265,56 @@ export const Dashboard = () => {
           <div className="space-y-4 py-4">
             {/* Cover Upload */}
             <div className="space-y-2">
-              <label className="text-sm font-medium">封面</label>
-              {coverPreview ? (
-                <div className="relative w-full aspect-video rounded-lg overflow-hidden border">
-                  <img src={coverPreview} alt="封面预览" className="h-full w-full object-cover" />
+              <label className="text-sm font-medium">智能短剧封面</label>
+              {(coverPreview || form.cover) ? (
+                <div className="relative w-full aspect-video rounded-lg overflow-hidden border group">
+                  <img 
+                    src={coverPreview || form.cover} 
+                    alt="封面预览" 
+                    className="h-full w-full object-cover" 
+                  />
                   <Button
                     variant="destructive"
                     size="icon"
-                    className="absolute top-2 right-2 h-7 w-7"
+                    className="absolute top-2 right-2 h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={clearCover}
+                    disabled={uploadingCover}
                   >
                     <X className="h-3.5 w-3.5" />
                   </Button>
+                  {uploadingCover && (
+                    <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                      <div className="h-8 w-8 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                    </div>
+                  )}
                 </div>
               ) : (
-                <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed rounded-lg cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors">
-                  <ImagePlus className="h-8 w-8 text-muted-foreground/40" />
-                  <span className="mt-2 text-sm text-muted-foreground/60">点击上传封面图片</span>
-                  <input type="file" accept="image/*" className="hidden" onChange={handleCoverChange} />
-                </label>
+                <div
+                  className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed rounded-lg cursor-pointer hover:border-primary/50 hover:bg-primary/5 transition-colors"
+                  onClick={() => uploadRef.current?.click()}
+                >
+                  {uploadingCover ? (
+                    <>
+                      <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                      <span className="mt-2 text-sm text-muted-foreground">上传中...</span>
+                    </>
+                  ) : (
+                    <>
+                      <ImagePlus className="h-8 w-8 text-muted-foreground/40" />
+                      <span className="mt-2 text-sm text-muted-foreground/60">点击上传封面图片</span>
+                    </>
+                  )}
+                </div>
               )}
+              <input
+                ref={uploadRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleCoverChange}
+                disabled={uploadingCover}
+              />
+              <p className="text-xs text-muted-foreground">选填，支持图片格式</p>
             </div>
 
             <div className="space-y-2">
@@ -285,7 +349,7 @@ export const Dashboard = () => {
             <Button variant="outline" onClick={() => setDialogOpen(false)}>
               取消
             </Button>
-            <Button onClick={handleCreate} disabled={!form.name.trim() || creating} className="shadow-lg shadow-primary/20">
+            <Button onClick={handleCreate} disabled={!form.name.trim() || creating || uploadingCover} className="shadow-lg shadow-primary/20">
               {creating ? '创建中...' : '创建'}
             </Button>
           </DialogFooter>

--- a/web/pages/Videos.tsx
+++ b/web/pages/Videos.tsx
@@ -1,39 +1,80 @@
-import { useCallback, useEffect, useState } from 'react'
-import { MonitorPlay, RefreshCw, Trash2, Loader2, Film, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { MonitorPlay, RefreshCw, Trash2, Loader2, Film, X, BookOpen, ArrowLeft, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Input } from '@/components/ui/input'
 import { api } from '@/services/api'
-import type { Video, Pagination } from '@/types'
+import type { Video, Pagination, Novel } from '@/types'
 import { TaskStatusEnum } from '@/types'
 import { statusColor, statusLabel, modelLabel } from '@/lib/helpers'
 import { toast } from 'sonner'
 
 export const VideosPage = () => {
+  const { id: novelIdStr } = useParams<{ id?: string }>()
+  const novelId = novelIdStr ? parseInt(novelIdStr) : null
+
   const [videos, setVideos] = useState<Video[]>([])
+  const [novels, setNovels] = useState<Novel[]>([])
+  const [currentNovel, setCurrentNovel] = useState<Novel | null>(null)
   const [pagination, setPagination] = useState<Pagination | null>(null)
   const [page, setPage] = useState(1)
+  const [searchKeyword, setSearchKeyword] = useState('')
   const [loading, setLoading] = useState(true)
   const [refreshingIds, setRefreshingIds] = useState<Set<number>>(new Set())
   const [deletingIds, setDeletingIds] = useState<Set<number>>(new Set())
 
-  const fetchVideos = useCallback(async (p: number) => {
-    setLoading(true)
+  const fetchNovelVideos = async (id: number) => {
     try {
-      const res = await api.getVideos(p, 20, '-id')
-      setVideos(res.data.items)
-      setPagination(res.data.pagination)
-    } catch (err) {
-      toast.error((err as Error).message || '获取视频列表失败')
+      setLoading(true)
+      const [novelRes, videosRes] = await Promise.all([
+        api.getNovel(id),
+        api.getNovelVideos(id)
+      ])
+      setCurrentNovel(novelRes.data)
+      setVideos(videosRes.data)
+    } catch (err: any) {
+      toast.error(err.message || '获取项目视频失败')
     } finally {
       setLoading(false)
     }
-  }, [])
+  }
+
+  const fetchNovels = async (p: number = page, search?: string) => {
+    try {
+      setLoading(true)
+      const res = await api.getNovels(p, 20, search)
+      setNovels(res.data.items)
+      setPagination(res.data.pagination)
+    } catch (err: any) {
+      toast.error(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   useEffect(() => {
-    fetchVideos(page)
-  }, [page, fetchVideos])
+    if (novelId) {
+      fetchNovelVideos(novelId)
+    } else {
+      fetchNovels(page, searchKeyword)
+    }
+  }, [novelId, page])
+
+  // 搜索处理
+  const handleSearch = () => {
+    setPage(1)
+    fetchNovels(1, searchKeyword)
+  }
+
+  // 按回车搜索
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSearch()
+    }
+  }
 
   const handleRefreshStatus = async (video: Video) => {
     setRefreshingIds((prev) => new Set(prev).add(video.id))
@@ -60,7 +101,9 @@ export const VideosPage = () => {
     try {
       await api.deleteVideo(video.id)
       toast.success('视频已删除')
-      fetchVideos(page)
+      if (novelId) {
+        fetchNovelVideos(novelId)
+      }
     } catch (err) {
       toast.error((err as Error).message || '删除视频失败')
     } finally {
@@ -126,25 +169,58 @@ export const VideosPage = () => {
   return (
     <div className="p-8 max-w-7xl mx-auto space-y-6">
       {/* Header */}
-      <div className="animate-fade-up flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-3">
-            <div className="relative">
-              <MonitorPlay className="h-8 w-8 text-primary" />
-              <div className="absolute inset-0 blur-lg bg-primary/30 rounded-full" />
-            </div>
-            <span className="gradient-text">视频库</span>
-          </h1>
-          <p className="text-muted-foreground mt-1.5 text-sm">所有项目的生成视频</p>
+      <div className="space-y-4">
+        <div className="animate-fade-up flex items-center gap-4">
+          {novelId && (
+            <Link to="/videos">
+              <Button variant="ghost" size="icon" className="flex-shrink-0">
+                <ArrowLeft className="h-5 w-5" />
+              </Button>
+            </Link>
+          )}
+          <div className="flex-shrink-0">
+            <h1 className="text-3xl font-bold tracking-tight flex items-center gap-3">
+              <div className="relative">
+                <MonitorPlay className="h-8 w-8 text-primary" />
+                <div className="absolute inset-0 blur-lg bg-primary/30 rounded-full" />
+              </div>
+              <span className="gradient-text">
+                {novelId ? (currentNovel?.name || '项目视频') : '视频库'}
+              </span>
+            </h1>
+            <p className="text-muted-foreground mt-1.5 text-sm">
+              {novelId
+                ? (currentNovel?.description || '该项目下的所有生成视频')
+                : '所有项目的生成视频'
+              }
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {!novelId && (
+              <>
+                <Input
+                  placeholder="搜索项目名称或作者..."
+                  value={searchKeyword}
+                  onChange={(e) => setSearchKeyword(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="w-48"
+                />
+                <Button onClick={handleSearch} disabled={loading} size="icon">
+                  <Search className="h-4 w-4" />
+                </Button>
+              </>
+            )}
+            <Button
+              variant="secondary"
+              onClick={() => novelId ? fetchNovelVideos(novelId) : fetchNovels(page, searchKeyword)}
+              disabled={loading}
+              className="flex-shrink-0"
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              刷新
+            </Button>
+          </div>
         </div>
-        <Button
-          variant="secondary"
-          onClick={() => fetchVideos(page)}
-          disabled={loading}
-        >
-          <RefreshCw className={`mr-2 h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-          刷新
-        </Button>
       </div>
 
       {/* Decorative line */}
@@ -165,86 +241,70 @@ export const VideosPage = () => {
         </div>
       )}
 
-      {/* Empty State */}
-      {!loading && videos.length === 0 && (
+      {/* Empty State - Projects */}
+      {!loading && !novelId && novels.length === 0 && (
+        <div className="animate-scale-in flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-muted-foreground/20 p-16 relative overflow-hidden">
+          <div className="absolute inset-0 animate-shimmer" />
+          <MonitorPlay className="mb-4 h-16 w-16 text-muted-foreground/30 animate-float" />
+          <p className="text-lg font-semibold text-muted-foreground">暂无项目</p>
+          <p className="text-sm text-muted-foreground/60 mt-2">请先创建项目</p>
+        </div>
+      )}
+
+      {/* Empty State - Videos */}
+      {!loading && novelId && videos.length === 0 && (
         <div className="animate-scale-in flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-muted-foreground/20 p-16 relative overflow-hidden">
           <div className="absolute inset-0 animate-shimmer" />
           <MonitorPlay className="mb-4 h-16 w-16 text-muted-foreground/30 animate-float" />
           <p className="text-lg font-semibold text-muted-foreground">暂无视频</p>
-          <p className="text-sm text-muted-foreground/60 mt-2">请在工作流中生成视频</p>
+          <p className="text-sm text-muted-foreground/60 mt-2">该项目还没有生成任何视频</p>
         </div>
       )}
 
-      {/* Video Grid */}
-      {!loading && videos.length > 0 && (
+      {/* Projects Grid */}
+      {!loading && !novelId && novels.length > 0 && (
         <>
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 stagger-children">
-            {videos.map((video) => (
-              <Card key={video.id} className="card-glow group overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-primary/30 hover:shadow-xl hover:shadow-primary/5 hover:-translate-y-0.5">
-                <CardContent className="relative p-0">
-                  {/* Video Preview */}
-                  <div className="aspect-video overflow-hidden">
-                    {renderVideoPreview(video)}
-                  </div>
-
-                  {/* Status Badge */}
-                  <Badge
-                    variant={statusColor(video.status) as any}
-                    className="absolute left-2.5 top-2.5 backdrop-blur-sm"
-                  >
-                    {statusLabel(video.status)}
-                  </Badge>
-
-                  {/* Hover Overlay */}
-                  <div className="absolute inset-0 flex items-center justify-center gap-3 bg-black/60 backdrop-blur-sm opacity-0 transition-all duration-200 group-hover:opacity-100">
-                    {canRefresh(video) && (
-                      <Button
-                        size="icon"
-                        variant="secondary"
-                        className="h-10 w-10 rounded-full"
-                        onClick={() => handleRefreshStatus(video)}
-                        disabled={refreshingIds.has(video.id)}
-                      >
-                        {refreshingIds.has(video.id) ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <RefreshCw className="h-4 w-4" />
-                        )}
-                      </Button>
+            {novels.map((novel) => (
+              <Link key={novel.id} to={`/videos/novel/${novel.id}`} className="group">
+                <Card className="card-glow overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-primary/30 hover:shadow-xl hover:shadow-primary/5 hover:-translate-y-0.5">
+                  {/* Cover Area */}
+                  <div className="relative aspect-video overflow-hidden">
+                    {novel.cover ? (
+                      <img
+                        src={novel.cover}
+                        alt={novel.name}
+                        className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-primary/20 via-primary/5 to-accent/10">
+                        <BookOpen className="h-12 w-12 text-muted-foreground/20 group-hover:text-primary/30 transition-colors duration-300" />
+                      </div>
                     )}
-                    <Button
-                      size="icon"
-                      variant="destructive"
-                      className="h-10 w-10 rounded-full"
-                      onClick={() => handleDelete(video)}
-                      disabled={deletingIds.has(video.id)}
+                    {/* Gradient Overlay */}
+                    <div className="absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+                    {/* Chapter Count Badge */}
+                    <Badge
+                      variant="secondary"
+                      className="absolute bottom-2.5 left-2.5 text-xs backdrop-blur-sm bg-black/40 border-white/10 text-white/90"
                     >
-                      {deletingIds.has(video.id) ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Trash2 className="h-4 w-4" />
-                      )}
-                    </Button>
+                      {novel.total_chapters ?? 0} 章节
+                    </Badge>
                   </div>
-                </CardContent>
-
-                <CardFooter className="flex flex-col items-start gap-2 p-4">
-                  <div className="flex w-full items-center justify-between">
-                    <span className="text-sm font-medium">
-                      视频 #{video.id}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      场景 #{video.scene_id}
-                    </span>
-                  </div>
-                  <div className="flex w-full items-center justify-between">
-                    <Badge variant="outline">{modelLabel(video.model_type)}</Badge>
-                    <span className="text-xs text-muted-foreground">
-                      {formatDate(video.created_at)}
-                    </span>
-                  </div>
-                </CardFooter>
-              </Card>
+                  {/* Info */}
+                  <CardContent className="p-4 space-y-1.5">
+                    <h3 className="font-semibold text-base truncate group-hover:text-primary transition-colors duration-200">{novel.name}</h3>
+                    {novel.author && (
+                      <p className="text-sm text-muted-foreground">{novel.author}</p>
+                    )}
+                    {novel.description && (
+                      <p className="text-sm text-muted-foreground/60 line-clamp-2">
+                        {novel.description}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </Link>
             ))}
           </div>
 
@@ -273,6 +333,79 @@ export const VideosPage = () => {
             </div>
           )}
         </>
+      )}
+
+      {/* Videos Grid */}
+      {!loading && novelId && videos.length > 0 && (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 stagger-children">
+          {videos.map((video) => (
+            <Card key={video.id} className="card-glow group overflow-hidden transition-all duration-300 hover:ring-2 hover:ring-primary/30 hover:shadow-xl hover:shadow-primary/5 hover:-translate-y-0.5">
+              <CardContent className="relative p-0">
+                {/* Video Preview */}
+                <div className="aspect-video overflow-hidden">
+                  {renderVideoPreview(video)}
+                </div>
+
+                {/* Status Badge */}
+                <Badge
+                  variant={statusColor(video.status) as any}
+                  className="absolute left-2.5 top-2.5 backdrop-blur-sm"
+                >
+                  {statusLabel(video.status)}
+                </Badge>
+
+                {/* Hover Overlay */}
+                <div className="absolute inset-0 flex items-center justify-center gap-3 bg-black/60 backdrop-blur-sm opacity-0 transition-all duration-200 group-hover:opacity-100">
+                  {canRefresh(video) && (
+                    <Button
+                      size="icon"
+                      variant="secondary"
+                      className="h-10 w-10 rounded-full"
+                      onClick={() => handleRefreshStatus(video)}
+                      disabled={refreshingIds.has(video.id)}
+                    >
+                      {refreshingIds.has(video.id) ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <RefreshCw className="h-4 w-4" />
+                      )}
+                    </Button>
+                  )}
+                  <Button
+                    size="icon"
+                    variant="destructive"
+                    className="h-10 w-10 rounded-full"
+                    onClick={() => handleDelete(video)}
+                    disabled={deletingIds.has(video.id)}
+                  >
+                    {deletingIds.has(video.id) ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+              </CardContent>
+
+              <CardFooter className="flex flex-col items-start gap-2 p-4">
+                <div className="flex w-full items-center justify-between">
+                  <span className="text-sm font-medium">
+                    视频 #{video.id}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    场景 #{video.scene_id}
+                  </span>
+                </div>
+                <div className="flex w-full items-center justify-between">
+                  <Badge variant="outline">{modelLabel(video.model_type)}</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {video.created_at && formatDate(video.created_at)}
+                  </span>
+                </div>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/web/services/api.ts
+++ b/web/services/api.ts
@@ -30,8 +30,8 @@ class ApiService {
   }
 
   // --- Novels ---
-  getNovels(page = 1, pageSize = 20): Promise<PaginationResponse<Novel>> {
-    return request(`/novel${qs({ page, page_size: pageSize })}`);
+  getNovels(page = 1, pageSize = 20, search?: string): Promise<PaginationResponse<Novel>> {
+    return request(`/novel${qs({ page, page_size: pageSize, search })}`);
   }
   getNovel(id: number): Promise<SingleResponse<Novel>> {
     return request(`/novel/${id}`);
@@ -123,6 +123,9 @@ class ApiService {
   }
   getChapterVideos(chapterId: number): Promise<SingleResponse<ChapterVideoItem[]>> {
     return request(`/video/chapter/${chapterId}`);
+  }
+  getNovelVideos(novelId: number): Promise<SingleResponse<Video[]>> {
+    return request(`/video/novel/${novelId}`);
   }
   generateVideo(data: { scene_id: number; model_type: number }): Promise<SingleResponse<Video>> {
     return request('/video/generate/', { method: 'POST', body: JSON.stringify(data) });


### PR DESCRIPTION
## ✨ 功能1：项目封面上传
- 新增项目创建时的封面上传组件
- 支持图片预览和上传状态显示
- 优化上传体验：预览 → 上传 → 完成，流程顺畅
- 封面上传失败时自动清理预览并提示

## ✨ 功能2：项目分类与视频库优化
- 视频库侧边栏新增项目分类入口
- 点击分类可查看对应分类的所有项目
- 视频列表页面优化：点击具体项目才显示该项目的视频
- 提升视频浏览的清晰度和用户体验

## 🎯 使用效果
- 创建项目时可以上传封面，项目展示更直观
- 视频库按项目分类组织，浏览更有条理
- 避免视频混淆，每个项目独立管理自己的视频

## ✅ 测试验证
- [x] 项目创建：封面上传正常，预览正常
- [x] 项目分类：侧边栏分类显示正常
- [x] 视频浏览：点击项目才显示对应视频
- [x] 删除功能：项目删除时相关数据清理正常

## 📸 截图
<img width="1532" height="944" alt="image" src="https://github.com/user-attachments/assets/6aeb6612-c76c-4239-b262-c3e070366d10" />
<img width="1895" height="894" alt="image" src="https://github.com/user-attachments/assets/0fedfa3f-978c-409a-a68f-82ca72328b17" />
<img width="1790" height="856" alt="image" src="https://github.com/user-attachments/assets/bcfd90e9-5b7b-4337-864f-87c19ddaaeca" />

