### PR TITLE
fix(database): migrate legacy schema before startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,18 +68,27 @@ video_task_reconciler = VideoTaskReconciler(
 )
 
 
-@asynccontextmanager
-async def lifespan(_: FastAPI):
+async def _initialize_database_schema() -> None:
+    """Initialize storage while keeping legacy PostgreSQL installs bootable."""
     await Tortoise.init(config=tortoise_config)
+    # PostgreSQL emits column comments for existing tables during safe schema
+    # generation. Add fields referenced by the current models first, otherwise
+    # startup fails before the compatibility migrations can run.
+    include_compat_indexes = not settings.GENERATE_SCHEMAS
+    await ensure_remake_schema(include_indexes=include_compat_indexes)
+    await ensure_voice_reference_schema(include_indexes=include_compat_indexes)
     if settings.GENERATE_SCHEMAS:
         await Tortoise.generate_schemas(safe=True)
     await ensure_ai_model_config_schema()
     await ensure_novel_analysis_schema()
-    await ensure_remake_schema()
     await ensure_usage_record_schema()
-    await ensure_voice_reference_schema()
     # 共享表团队增量列：无条件补齐（旧库在关闭开关时同样需要，纯增量幂等）
     await ensure_shared_team_columns()
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    await _initialize_database_schema()
     await remake_upload_service.cleanup_expired()
     await backfill_last_frame_continuity()
     await ensure_media_library_seed_data()

--- a/services/schema_compat.py
+++ b/services/schema_compat.py
@@ -115,7 +115,7 @@ async def ensure_novel_analysis_schema() -> None:
         await connection.execute_script("".join(statements))
 
 
-async def ensure_remake_schema() -> None:
+async def ensure_remake_schema(*, include_indexes: bool = True) -> None:
     """补齐重制项目共享字段；只做增量操作且允许重复启动。"""
     connection = Tortoise.get_connection("default")
     if settings.DATABASE_URL.startswith("sqlite"):
@@ -145,12 +145,12 @@ async def ensure_remake_schema() -> None:
         for name, definition in task_definitions.items():
             if name not in task_existing:
                 statements.append(f"ALTER TABLE ai_tasks ADD COLUMN {name} {definition};")
-        if "workflow_kind" not in novel_existing:
+        if include_indexes and "workflow_kind" not in novel_existing:
             statements.append(
                 "CREATE INDEX IF NOT EXISTS idx_novels_workflow_kind "
                 "ON novels(workflow_kind);"
             )
-        if "creation_idempotency_key" not in novel_existing:
+        if include_indexes and "creation_idempotency_key" not in novel_existing:
             statements.append(
                 "CREATE UNIQUE INDEX IF NOT EXISTS uid_novels_creation_idempotency_key "
                 "ON novels(creation_idempotency_key);"
@@ -160,22 +160,29 @@ async def ensure_remake_schema() -> None:
         return
 
     if settings.DATABASE_URL.startswith(("postgres://", "postgresql://")):
-        await connection.execute_script(
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS workflow_kind VARCHAR(32) NOT NULL DEFAULT 'script';"
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS aspect_ratio VARCHAR(16);"
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS resolution VARCHAR(32);"
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS custom_style_prompt TEXT;"
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS creation_idempotency_key VARCHAR(64);"
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS creation_payload_hash VARCHAR(64);"
-            "ALTER TABLE ai_tasks ADD COLUMN IF NOT EXISTS stage VARCHAR(32);"
-            "ALTER TABLE ai_tasks ADD COLUMN IF NOT EXISTS progress INT NOT NULL DEFAULT 0;"
-            "CREATE INDEX IF NOT EXISTS idx_novels_workflow_kind ON novels(workflow_kind);"
-            "CREATE UNIQUE INDEX IF NOT EXISTS uid_novels_creation_idempotency_key "
-            "ON novels(creation_idempotency_key);"
-        )
+        statements = [
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS workflow_kind VARCHAR(32) NOT NULL DEFAULT 'script';",
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS aspect_ratio VARCHAR(16);",
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS resolution VARCHAR(32);",
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS custom_style_prompt TEXT;",
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS creation_idempotency_key VARCHAR(64);",
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS creation_payload_hash VARCHAR(64);",
+            "ALTER TABLE IF EXISTS ai_tasks ADD COLUMN IF NOT EXISTS stage VARCHAR(32);",
+            "ALTER TABLE IF EXISTS ai_tasks ADD COLUMN IF NOT EXISTS progress INT NOT NULL DEFAULT 0;",
+        ]
+        if include_indexes:
+            statements.append(
+                "DO $$ BEGIN "
+                "IF to_regclass('novels') IS NOT NULL THEN "
+                "CREATE INDEX IF NOT EXISTS idx_novels_workflow_kind ON novels(workflow_kind);"
+                "CREATE UNIQUE INDEX IF NOT EXISTS uid_novels_creation_idempotency_key "
+                "ON novels(creation_idempotency_key);"
+                "END IF; END $$;"
+            )
+        await connection.execute_script("".join(statements))
 
 
-async def ensure_voice_reference_schema() -> None:
+async def ensure_voice_reference_schema(*, include_indexes: bool = True) -> None:
     """Add reusable voice fields for both existing SQLite and PostgreSQL installs."""
     connection = Tortoise.get_connection("default")
     if settings.DATABASE_URL.startswith("sqlite"):
@@ -193,19 +200,38 @@ async def ensure_voice_reference_schema() -> None:
                 for name, definition in definitions.items()
                 if name not in existing
             ]
+            if include_indexes and "source" not in existing:
+                statements.append(
+                    "CREATE INDEX IF NOT EXISTS idx_audio_references_source "
+                    "ON audio_references(source);"
+                )
+            if include_indexes and "team_id" not in existing:
+                statements.append(
+                    "CREATE INDEX IF NOT EXISTS idx_audio_references_team_id "
+                    "ON audio_references(team_id);"
+                )
             if statements:
                 await connection.execute_script("".join(statements))
         return
     if settings.DATABASE_URL.startswith(("postgres://", "postgresql://")):
-        await connection.execute_script(
-            "ALTER TABLE novels ADD COLUMN IF NOT EXISTS narrator_audio_reference_id INT;"
-            "ALTER TABLE audio_references ADD COLUMN IF NOT EXISTS source VARCHAR(16) NOT NULL DEFAULT 'system';"
-            "ALTER TABLE audio_references ADD COLUMN IF NOT EXISTS duration DOUBLE PRECISION;"
-            "ALTER TABLE audio_references ADD COLUMN IF NOT EXISTS team_id INT;"
-            "ALTER TABLE audio_references ADD COLUMN IF NOT EXISTS created_by INT;"
-            "CREATE INDEX IF NOT EXISTS idx_audio_references_source ON audio_references(source);"
-            "CREATE INDEX IF NOT EXISTS idx_audio_references_team_id ON audio_references(team_id);"
-        )
+        statements = [
+            "ALTER TABLE IF EXISTS novels ADD COLUMN IF NOT EXISTS narrator_audio_reference_id INT;",
+            "ALTER TABLE IF EXISTS audio_references ADD COLUMN IF NOT EXISTS source VARCHAR(16) NOT NULL DEFAULT 'system';",
+            "ALTER TABLE IF EXISTS audio_references ADD COLUMN IF NOT EXISTS duration DOUBLE PRECISION;",
+            "ALTER TABLE IF EXISTS audio_references ADD COLUMN IF NOT EXISTS team_id INT;",
+            "ALTER TABLE IF EXISTS audio_references ADD COLUMN IF NOT EXISTS created_by INT;",
+        ]
+        if include_indexes:
+            statements.append(
+                "DO $$ BEGIN "
+                "IF to_regclass('audio_references') IS NOT NULL THEN "
+                "CREATE INDEX IF NOT EXISTS idx_audio_references_source "
+                "ON audio_references(source);"
+                "CREATE INDEX IF NOT EXISTS idx_audio_references_team_id "
+                "ON audio_references(team_id);"
+                "END IF; END $$;"
+            )
+        await connection.execute_script("".join(statements))
 
 
 async def ensure_shared_team_columns() -> None:

--- a/test/test_main_schema_startup.py
+++ b/test/test_main_schema_startup.py
@@ -1,0 +1,47 @@
+import pytest
+
+import main as app_main
+
+
+def _record(events: list[tuple[str, dict[str, object]]], name: str):
+    async def invoke(*_args, **kwargs):
+        events.append((name, kwargs))
+
+    return invoke
+
+
+@pytest.mark.asyncio
+async def test_legacy_columns_are_added_before_safe_schema_generation(monkeypatch):
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(app_main.settings, "GENERATE_SCHEMAS", True)
+    monkeypatch.setattr(
+        app_main.Tortoise,
+        "init",
+        _record(events, "init"),
+    )
+    monkeypatch.setattr(
+        app_main.Tortoise,
+        "generate_schemas",
+        _record(events, "generate"),
+    )
+    for name in (
+        "ensure_remake_schema",
+        "ensure_voice_reference_schema",
+        "ensure_ai_model_config_schema",
+        "ensure_novel_analysis_schema",
+        "ensure_usage_record_schema",
+        "ensure_shared_team_columns",
+    ):
+        monkeypatch.setattr(app_main, name, _record(events, name))
+
+    await app_main._initialize_database_schema()
+
+    names = [name for name, _kwargs in events]
+    assert names[:4] == [
+        "init",
+        "ensure_remake_schema",
+        "ensure_voice_reference_schema",
+        "generate",
+    ]
+    assert events[1][1] == {"include_indexes": False}
+    assert events[2][1] == {"include_indexes": False}

--- a/test/test_services/test_schema_compat.py
+++ b/test/test_services/test_schema_compat.py
@@ -182,3 +182,63 @@ async def test_remake_schema_adds_project_and_task_fields_once_across_repeated_s
     assert "ADD COLUMN stage VARCHAR(32)" in script
     assert "ADD COLUMN progress INT NOT NULL DEFAULT 0" in script
     assert "CREATE UNIQUE INDEX IF NOT EXISTS" in script
+
+
+@pytest.mark.asyncio
+async def test_postgres_remake_schema_is_safe_before_tables_are_created(monkeypatch):
+    connection = AsyncMock()
+    monkeypatch.setattr(
+        "services.schema_compat.Tortoise.get_connection",
+        lambda _: connection,
+    )
+    monkeypatch.setattr(
+        "services.schema_compat.settings.DATABASE_URL",
+        "postgresql://compat-test",
+    )
+
+    await ensure_remake_schema(include_indexes=False)
+
+    script = connection.execute_script.await_args.args[0]
+    assert "ALTER TABLE IF EXISTS novels" in script
+    assert "ALTER TABLE IF EXISTS ai_tasks" in script
+    assert "CREATE INDEX" not in script
+
+
+@pytest.mark.asyncio
+async def test_postgres_voice_schema_is_safe_before_tables_are_created(monkeypatch):
+    connection = AsyncMock()
+    monkeypatch.setattr(
+        "services.schema_compat.Tortoise.get_connection",
+        lambda _: connection,
+    )
+    monkeypatch.setattr(
+        "services.schema_compat.settings.DATABASE_URL",
+        "postgresql://compat-test",
+    )
+
+    await ensure_voice_reference_schema(include_indexes=False)
+
+    script = connection.execute_script.await_args.args[0]
+    assert "ALTER TABLE IF EXISTS novels" in script
+    assert "ALTER TABLE IF EXISTS audio_references" in script
+    assert "CREATE INDEX" not in script
+
+
+@pytest.mark.asyncio
+async def test_postgres_compat_indexes_are_guarded_by_table_existence(monkeypatch):
+    connection = AsyncMock()
+    monkeypatch.setattr(
+        "services.schema_compat.Tortoise.get_connection",
+        lambda _: connection,
+    )
+    monkeypatch.setattr(
+        "services.schema_compat.settings.DATABASE_URL",
+        "postgresql://compat-test",
+    )
+
+    await ensure_remake_schema()
+    await ensure_voice_reference_schema()
+
+    scripts = [call.args[0] for call in connection.execute_script.await_args_list]
+    assert "to_regclass('novels')" in scripts[0]
+    assert "to_regclass('audio_references')" in scripts[1]


### PR DESCRIPTION
## 问题

重制工坊首次部署到已有 PostgreSQL 数据库时，Tortoise 在兼容迁移执行前就为当前模型生成字段注释，导致旧表缺少 `ai_tasks.stage` 时启动失败。

## 修复

- 在安全建表前补齐旧库已有表的重制与音色字段
- PostgreSQL 使用 `ALTER TABLE IF EXISTS ... ADD COLUMN IF NOT EXISTS`，兼容已有库和全新库
- 索引只在对应表存在时创建
- 抽取可测试的数据库初始化步骤，确保迁移顺序不会回归
- 不删除、不重命名、不覆盖历史字段或业务数据

## 验证

- 后端全量：707 passed, 109 skipped
- PostgreSQL 迁移顺序与缺表兼容测试通过
- 鉴权专项测试通过
- 前端：432 tests passed
- TypeScript 类型检查通过
- 生产构建通过
