### PR TITLE
feat(storyboard): add focused prompt editing

### DIFF
--- a/web/src/components/ScenePromptEditor.spec.ts
+++ b/web/src/components/ScenePromptEditor.spec.ts
@@ -103,6 +103,48 @@ describe('ScenePromptEditor', () => {
     expect((video.element as HTMLVideoElement).muted).toBe(true)
   })
 
+  it('centers hover previews above or below the referenced token instead of beside it', async () => {
+    vi.stubGlobal('innerWidth', 1000)
+    vi.stubGlobal('innerHeight', 800)
+    const wrapper = mount(ScenePromptEditor, {
+      props: { modelValue: '@{断罪山脉}', options, focusMode: true },
+      global: { components: { AppButton }, stubs: { Teleport: true } },
+    })
+    const mention = wrapper.get<HTMLElement>('[data-mention-id="scene-1"]')
+    const rect = vi.spyOn(mention.element, 'getBoundingClientRect').mockReturnValue({
+      left: 450,
+      right: 550,
+      top: 500,
+      bottom: 520,
+      width: 100,
+      height: 20,
+      x: 450,
+      y: 500,
+      toJSON: () => ({}),
+    })
+
+    await mention.trigger('pointerover')
+
+    expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('left: 290px')
+    expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('top: 164px')
+
+    await mention.trigger('pointerout')
+    rect.mockReturnValue({
+      left: 450,
+      right: 550,
+      top: 40,
+      bottom: 60,
+      width: 100,
+      height: 20,
+      x: 450,
+      y: 40,
+      toJSON: () => ({}),
+    })
+    await mention.trigger('pointerover')
+    expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('left: 290px')
+    expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('top: 72px')
+  })
+
   it('does not show hover previews outside focus mode', async () => {
     const wrapper = mount(ScenePromptEditor, {
       props: { modelValue: '@{断罪山脉}', options },

--- a/web/src/components/ScenePromptEditor.spec.ts
+++ b/web/src/components/ScenePromptEditor.spec.ts
@@ -69,6 +69,50 @@ describe('ScenePromptEditor', () => {
     expect(wrapper.find('.image-lightbox').exists()).toBe(true)
   })
 
+  it('previews referenced images and videos on hover in focus mode only', async () => {
+    const videoOption: ScenePromptMentionOption = {
+      id: 'video-5',
+      kind: 'video',
+      label: '走廊参考视频',
+      syntax: '@{视频#走廊参考视频}',
+      group: '参考视频',
+      previewUrl: '/media/hallway.mp4',
+      thumbnailUrl: '/media/hallway.mp4',
+    }
+    const wrapper = mount(ScenePromptEditor, {
+      props: {
+        modelValue: '@{断罪山脉} 转场至 @{视频#走廊参考视频}',
+        options: [...options, videoOption],
+        focusMode: true,
+      },
+      global: { components: { AppButton }, stubs: { Teleport: true } },
+    })
+
+    await wrapper.get('[data-mention-id="scene-1"]').trigger('pointerover')
+    expect(wrapper.get('.scene-prompt-hover-preview img').attributes('src')).toBe('/media/mountain.png')
+    expect(wrapper.get('.scene-prompt-hover-preview').attributes('role')).toBe('tooltip')
+
+    await wrapper.get('[data-mention-id="scene-1"]').trigger('pointerout')
+    expect(wrapper.find('.scene-prompt-hover-preview').exists()).toBe(false)
+
+    await wrapper.get('[data-mention-id="video-5"]').trigger('pointerover')
+    const video = wrapper.get('.scene-prompt-hover-preview video')
+    expect(video.attributes('src')).toBe('/media/hallway.mp4')
+    expect(video.attributes('autoplay')).toBeDefined()
+    expect(video.attributes('loop')).toBeDefined()
+    expect((video.element as HTMLVideoElement).muted).toBe(true)
+  })
+
+  it('does not show hover previews outside focus mode', async () => {
+    const wrapper = mount(ScenePromptEditor, {
+      props: { modelValue: '@{断罪山脉}', options },
+      global: { components: { AppButton }, stubs: { Teleport: true } },
+    })
+
+    await wrapper.get('[data-mention-id="scene-1"]').trigger('pointerover')
+    expect(wrapper.find('.scene-prompt-hover-preview').exists()).toBe(false)
+  })
+
   it('将音频引用渲染为可点击播放的音色标签', async () => {
     const play = vi.fn().mockResolvedValue(undefined)
     const pause = vi.fn()

--- a/web/src/components/ScenePromptEditor.spec.ts
+++ b/web/src/components/ScenePromptEditor.spec.ts
@@ -91,6 +91,8 @@ describe('ScenePromptEditor', () => {
     await wrapper.get('[data-mention-id="scene-1"]').trigger('pointerover')
     expect(wrapper.get('.scene-prompt-hover-preview img').attributes('src')).toBe('/media/mountain.png')
     expect(wrapper.get('.scene-prompt-hover-preview').attributes('role')).toBe('tooltip')
+    expect(wrapper.find('.scene-prompt-hover-preview footer').exists()).toBe(false)
+    expect(wrapper.get('.scene-prompt-hover-preview').text()).toBe('')
 
     await wrapper.get('[data-mention-id="scene-1"]').trigger('pointerout')
     expect(wrapper.find('.scene-prompt-hover-preview').exists()).toBe(false)
@@ -126,7 +128,7 @@ describe('ScenePromptEditor', () => {
     await mention.trigger('pointerover')
 
     expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('left: 290px')
-    expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('top: 164px')
+    expect(wrapper.get('.scene-prompt-hover-preview').attributes('style')).toContain('top: 251.75px')
 
     await mention.trigger('pointerout')
     rect.mockReturnValue({

--- a/web/src/components/ScenePromptEditor.vue
+++ b/web/src/components/ScenePromptEditor.vue
@@ -24,9 +24,11 @@ const props = withDefaults(defineProps<{
   options: ScenePromptMentionOption[]
   placeholder?: string
   embedded?: boolean
+  focusMode?: boolean
 }>(), {
   placeholder: '请输入分镜视频提示词。描述镜头、主体动作、运镜、光线、画面风格和声音。',
   embedded: false,
+  focusMode: false,
 })
 
 const emit = defineEmits<{
@@ -513,7 +515,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <section class="scene-prompt-editor" :class="{ 'is-embedded': embedded }">
+  <section class="scene-prompt-editor" :class="{ 'is-embedded': embedded, 'is-focus-mode': focusMode }">
     <div
       ref="editor"
       class="scene-prompt-editor__input"
@@ -612,9 +614,12 @@ onBeforeUnmount(() => {
 .scene-prompt-editor:focus-within { border-color: color-mix(in srgb,var(--app-accent) 46%,var(--app-border)); box-shadow: 0 0 0 3px color-mix(in srgb,var(--app-accent) 9%,transparent),0 10px 28px rgb(17 24 39 / 4%); }
 .scene-prompt-editor.is-embedded { min-height: 320px; max-height: 600px; align-self: start; border: 0; border-radius: 0; background: transparent; box-shadow: none; }
 .scene-prompt-editor.is-embedded:focus-within { border-color: transparent; box-shadow: none; }
+.scene-prompt-editor.is-focus-mode { width: 100%; height: 100%; min-height: 0; max-height: none; border: 0; border-radius: 0; background: transparent; box-shadow: none; }
+.scene-prompt-editor.is-focus-mode:focus-within { border-color: transparent; box-shadow: none; }
 .scene-prompt-editor__input { min-width: 0; min-height: 420px; overflow: auto; padding: 1px 16px 20px; outline: 0; color: var(--app-text-secondary); background: var(--app-surface); font-size: 11px; line-height: 1.9; white-space: pre-wrap; overflow-wrap: anywhere; caret-color: var(--app-accent); }
 .scene-prompt-editor.is-embedded .scene-prompt-editor__input { min-height: 320px; max-height: 600px; overflow-y: auto; background: transparent; scrollbar-width: none; }
 .scene-prompt-editor.is-embedded .scene-prompt-editor__input::-webkit-scrollbar { display: none; }
+.scene-prompt-editor.is-focus-mode .scene-prompt-editor__input { height: 100%; min-height: 0; max-height: none; padding: 24px 28px 40px; background: transparent; font-size: 14px; line-height: 2; scrollbar-width: thin; scrollbar-color: var(--app-border-strong) transparent; }
 .scene-prompt-editor__input:focus { background: color-mix(in srgb,var(--app-surface) 98%,var(--app-accent)); }
 .scene-prompt-editor__input[data-empty='true']::before { color: var(--app-text-muted); content: attr(data-placeholder); pointer-events: none; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__mention) { display: inline-flex; max-width: 220px; min-height: 24px; align-items: center; gap: 5px; margin: 0 2px; padding: 2px 7px 2px 3px; border-radius: 7px; color: var(--app-text-secondary); background: var(--app-surface-muted); box-shadow: inset 0 0 0 1px var(--app-border); font-size: 10px; font-weight: 650; line-height: 20px; vertical-align: middle; user-select: all; }

--- a/web/src/components/ScenePromptEditor.vue
+++ b/web/src/components/ScenePromptEditor.vue
@@ -327,13 +327,14 @@ function placeHoverPreview(anchor: HTMLElement) {
   const width = Math.min(420, window.innerWidth - 24)
   const height = Math.min(324, window.innerHeight - 24)
   const gap = 12
-  const preferredLeft = rect.right + gap
-  const left = preferredLeft + width <= window.innerWidth - 12
-    ? preferredLeft
-    : rect.left - width - gap >= 12
-      ? rect.left - width - gap
-      : Math.max(12, Math.min(rect.left, window.innerWidth - width - 12))
-  const preferredTop = rect.top + rect.height / 2 - height / 2
+  const left = Math.max(12, Math.min(
+    rect.left + rect.width / 2 - width / 2,
+    window.innerWidth - width - 12,
+  ))
+  const spaceAbove = rect.top - gap
+  const spaceBelow = window.innerHeight - rect.bottom - gap
+  const showAbove = spaceAbove >= height || spaceAbove >= spaceBelow
+  const preferredTop = showAbove ? rect.top - height - gap : rect.bottom + gap
   const top = Math.max(12, Math.min(preferredTop, window.innerHeight - height - 12))
   hoverPreviewPosition.value = { left, top }
 }
@@ -733,9 +734,9 @@ onBeforeUnmount(() => {
 .scene-prompt-editor__input :deep(.scene-prompt-editor__duration-icon),.scene-prompt-editor__input :deep(.scene-prompt-editor__audio-icon) { display: inline-grid; width: 14px; height: 14px; flex: 0 0 14px; place-items: center; color: currentColor; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__audio-icon) { width: 18px; height: 18px; flex-basis: 18px; border-radius: 6px; color: var(--app-accent); background: color-mix(in srgb,var(--app-accent) 10%,transparent); transition: color .16s ease,background .16s ease,transform .16s ease; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__mention.is-audio.is-playing .scene-prompt-editor__audio-icon) { color: #fff; background: var(--app-accent); transform: scale(.94); }
-.scene-prompt-hover-preview { position: fixed; z-index: 178; display: grid; width: min(420px,calc(100vw - 24px)); grid-template-rows: minmax(0,280px) 44px; overflow: hidden; border: 1px solid var(--app-border); border-radius: 16px; color: var(--app-text); background: var(--app-surface-raised); box-shadow: 0 24px 70px rgb(12 16 28 / 28%); pointer-events: none; }
+.scene-prompt-hover-preview { position: fixed; z-index: 178; display: grid; width: min(420px,calc(100vw - 24px)); grid-template-rows: minmax(0,280px) 44px; overflow: hidden; border: 0; border-radius: 16px; color: var(--app-text); background: var(--app-surface-raised); box-shadow: 0 24px 70px rgb(12 16 28 / 28%); pointer-events: none; }
 .scene-prompt-hover-preview > img,.scene-prompt-hover-preview > video { display: block; width: 100%; height: 280px; background: #171a21; object-fit: contain; }
-.scene-prompt-hover-preview > footer { display: grid; min-width: 0; grid-template-columns: 18px minmax(0,1fr) auto; align-items: center; gap: 7px; padding: 0 12px; border-top: 1px solid var(--app-border); background: var(--app-surface); }
+.scene-prompt-hover-preview > footer { display: grid; min-width: 0; grid-template-columns: 18px minmax(0,1fr) auto; align-items: center; gap: 7px; padding: 0 12px; border: 0; background: var(--app-surface); }
 .scene-prompt-hover-preview > footer svg { color: var(--app-accent); }
 .scene-prompt-hover-preview > footer strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .scene-prompt-hover-preview > footer small { color: var(--app-text-muted); font-size: 9px; }

--- a/web/src/components/ScenePromptEditor.vue
+++ b/web/src/components/ScenePromptEditor.vue
@@ -531,13 +531,27 @@ function closePreview() {
   previewOption.value = null
 }
 
-function handleWindowKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape' && durationEditorOpen.value) {
+function consumeEscape() {
+  if (durationEditorOpen.value) {
     closeDurationEditor()
-    return
+    return true
   }
-  if (event.key === 'Escape' && previewOption.value) closePreview()
+  if (previewOption.value) {
+    closePreview()
+    return true
+  }
+  if (menuOpen.value) {
+    menuOpen.value = false
+    return true
+  }
+  return false
 }
+
+function handleWindowKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && consumeEscape()) event.preventDefault()
+}
+
+defineExpose({ consumeEscape })
 
 watch(() => props.modelValue, () => {
   if (editorValue() === props.modelValue) return

--- a/web/src/components/ScenePromptEditor.vue
+++ b/web/src/components/ScenePromptEditor.vue
@@ -325,7 +325,7 @@ function closeHoverPreview() {
 function placeHoverPreview(anchor: HTMLElement) {
   const rect = anchor.getBoundingClientRect()
   const width = Math.min(420, window.innerWidth - 24)
-  const height = Math.min(324, window.innerHeight - 24)
+  const height = Math.min(width * 9 / 16, window.innerHeight - 24)
   const gap = 12
   const left = Math.max(12, Math.min(
     rect.left + rect.width / 2 - width / 2,
@@ -623,7 +623,6 @@ onBeforeUnmount(() => {
         >
           <video v-if="hoverPreviewOption.kind === 'video'" :src="hoverPreviewSource" muted autoplay loop playsinline preload="metadata" />
           <img v-else :src="hoverPreviewSource" :alt="hoverPreviewOption.label" />
-          <footer><component :is="hoverPreviewOption.kind === 'video' ? Film : ImageIcon" :size="14" /><strong>{{ hoverPreviewOption.label }}</strong><small>{{ hoverPreviewOption.kind === 'video' ? '视频预览' : '图片预览' }}</small></footer>
         </aside>
       </Transition>
     </Teleport>
@@ -732,12 +731,8 @@ onBeforeUnmount(() => {
 .scene-prompt-editor__input :deep(.scene-prompt-editor__duration-icon),.scene-prompt-editor__input :deep(.scene-prompt-editor__audio-icon) { display: inline-grid; width: 14px; height: 14px; flex: 0 0 14px; place-items: center; color: currentColor; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__audio-icon) { width: 18px; height: 18px; flex-basis: 18px; border-radius: 6px; color: var(--app-accent); background: color-mix(in srgb,var(--app-accent) 10%,transparent); transition: color .16s ease,background .16s ease,transform .16s ease; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__mention.is-audio.is-playing .scene-prompt-editor__audio-icon) { color: #fff; background: var(--app-accent); transform: scale(.94); }
-.scene-prompt-hover-preview { position: fixed; z-index: 178; display: grid; width: min(420px,calc(100vw - 24px)); grid-template-rows: minmax(0,280px) 44px; overflow: hidden; border: 0; border-radius: 16px; color: var(--app-text); background: var(--app-surface-raised); box-shadow: 0 24px 70px rgb(12 16 28 / 28%); pointer-events: none; }
-.scene-prompt-hover-preview > img,.scene-prompt-hover-preview > video { display: block; width: 100%; height: 280px; background: #171a21; object-fit: contain; }
-.scene-prompt-hover-preview > footer { display: grid; min-width: 0; grid-template-columns: 18px minmax(0,1fr) auto; align-items: center; gap: 7px; padding: 0 12px; border: 0; background: var(--app-surface); }
-.scene-prompt-hover-preview > footer svg { color: var(--app-accent); }
-.scene-prompt-hover-preview > footer strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
-.scene-prompt-hover-preview > footer small { color: var(--app-text-muted); font-size: 9px; }
+.scene-prompt-hover-preview { position: fixed; z-index: 178; display: block; width: min(420px,calc(100vw - 24px)); aspect-ratio: 16/9; overflow: hidden; border: 0; border-radius: 16px; background: transparent; box-shadow: none; pointer-events: none; }
+.scene-prompt-hover-preview > img,.scene-prompt-hover-preview > video { display: block; width: 100%; height: 100%; border: 0; background: transparent; object-fit: cover; }
 .scene-prompt-hover-preview-enter-active,.scene-prompt-hover-preview-leave-active { transition: opacity .14s ease,transform .16s cubic-bezier(.2,.72,.2,1); transform-origin: center; }
 .scene-prompt-hover-preview-enter-from,.scene-prompt-hover-preview-leave-to { opacity: 0; transform: translateY(4px) scale(.985); }
 .scene-prompt-mentions { position: fixed; z-index: 170; display: grid; width: min(340px,calc(100vw - 24px)); max-height: 340px; grid-template-rows: auto minmax(0,1fr) auto; overflow: hidden; border-radius: 13px; color: var(--app-text-secondary); background: var(--app-surface-raised); box-shadow: var(--app-shadow), inset 0 0 0 1px var(--app-border); backdrop-filter: blur(16px); }

--- a/web/src/components/ScenePromptEditor.vue
+++ b/web/src/components/ScenePromptEditor.vue
@@ -552,8 +552,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape' && consumeEscape()) event.preventDefault()
 }
 
-defineExpose({ consumeEscape })
-
 watch(() => props.modelValue, () => {
   if (editorValue() === props.modelValue) return
   renderValue()

--- a/web/src/components/ScenePromptEditor.vue
+++ b/web/src/components/ScenePromptEditor.vue
@@ -43,6 +43,8 @@ const menuPosition = ref({ left: 0, top: 0 })
 const triggerTextNode = ref<Text | null>(null)
 const triggerStartOffset = ref(0)
 const previewOption = ref<ScenePromptMentionOption | null>(null)
+const hoverPreviewOption = ref<ScenePromptMentionOption | null>(null)
+const hoverPreviewPosition = ref({ left: 0, top: 0 })
 const durationAnchor = ref<HTMLElement | null>(null)
 const durationInput = ref<HTMLInputElement | null>(null)
 const durationEditorOpen = ref(false)
@@ -73,6 +75,8 @@ const groupedOptions = computed(() => {
 const activeOption = computed(() => filteredOptions.value[activeIndex.value] || null)
 const durationMentionOption = computed(() => filteredOptions.value.find(item => item.kind === 'duration') || null)
 const imagePreview = computed(() => previewOption.value?.kind !== 'video' ? previewOption.value : null)
+const hoverPreviewSource = computed(() => hoverPreviewOption.value?.previewUrl || hoverPreviewOption.value?.thumbnailUrl || '')
+const hoverPreviewStyle = computed(() => ({ left: `${hoverPreviewPosition.value.left}px`, top: `${hoverPreviewPosition.value.top}px` }))
 const menuStyle = computed(() => ({ left: `${menuPosition.value.left}px`, top: `${menuPosition.value.top}px` }))
 const durationStyle = computed(() => ({ left: `${durationPosition.value.left}px`, top: `${durationPosition.value.top}px` }))
 const durationNumber = computed(() => Number(durationValue.value))
@@ -187,6 +191,7 @@ function findNextMention(value: string, start: number) {
 
 function renderValue(value = props.modelValue) {
   if (!editor.value) return
+  closeHoverPreview()
   editor.value.querySelectorAll<HTMLElement>('.scene-prompt-editor__duration-icon, .scene-prompt-editor__audio-icon').forEach(host => render(null, host))
   const fragment = document.createDocumentFragment()
   let offset = 0
@@ -309,7 +314,64 @@ function selectMention(option: ScenePromptMentionOption) {
 }
 
 function openPreview(option: ScenePromptMentionOption) {
+  closeHoverPreview()
   if (option.previewUrl) previewOption.value = option
+}
+
+function closeHoverPreview() {
+  hoverPreviewOption.value = null
+}
+
+function placeHoverPreview(anchor: HTMLElement) {
+  const rect = anchor.getBoundingClientRect()
+  const width = Math.min(420, window.innerWidth - 24)
+  const height = Math.min(324, window.innerHeight - 24)
+  const gap = 12
+  const preferredLeft = rect.right + gap
+  const left = preferredLeft + width <= window.innerWidth - 12
+    ? preferredLeft
+    : rect.left - width - gap >= 12
+      ? rect.left - width - gap
+      : Math.max(12, Math.min(rect.left, window.innerWidth - width - 12))
+  const preferredTop = rect.top + rect.height / 2 - height / 2
+  const top = Math.max(12, Math.min(preferredTop, window.innerHeight - height - 12))
+  hoverPreviewPosition.value = { left, top }
+}
+
+function showHoverPreview(mention: HTMLElement) {
+  if (!props.focusMode) return
+  const option = props.options.find(item => item.id === mention.dataset.mentionId)
+  if (!option || option.kind === 'audio' || option.kind === 'duration' || !(option.previewUrl || option.thumbnailUrl)) return
+  placeHoverPreview(mention)
+  hoverPreviewOption.value = option
+}
+
+function mentionFromEvent(event: Event) {
+  const target = event.target
+  return target instanceof Element ? target.closest<HTMLElement>('[data-mention-id]') : null
+}
+
+function handleEditorPointerover(event: PointerEvent) {
+  const mention = mentionFromEvent(event)
+  if (!mention || (event.relatedTarget instanceof Node && mention.contains(event.relatedTarget))) return
+  showHoverPreview(mention)
+}
+
+function handleEditorPointerout(event: PointerEvent) {
+  const mention = mentionFromEvent(event)
+  if (!mention || (event.relatedTarget instanceof Node && mention.contains(event.relatedTarget))) return
+  if (hoverPreviewOption.value?.id === mention.dataset.mentionId) closeHoverPreview()
+}
+
+function handleEditorFocusin(event: FocusEvent) {
+  const mention = mentionFromEvent(event)
+  if (mention) showHoverPreview(mention)
+}
+
+function handleEditorFocusout(event: FocusEvent) {
+  const mention = mentionFromEvent(event)
+  if (!mention || (event.relatedTarget instanceof Node && mention.contains(event.relatedTarget))) return
+  if (hoverPreviewOption.value?.id === mention.dataset.mentionId) closeHoverPreview()
 }
 
 function syncAudioMentionState() {
@@ -526,10 +588,32 @@ onBeforeUnmount(() => {
       :data-placeholder="placeholder"
       spellcheck="true"
       @input="handleInput"
+      @scroll.passive="closeHoverPreview"
       @pointerdown="handleEditorPointerdown"
+      @pointerover="handleEditorPointerover"
+      @pointerout="handleEditorPointerout"
       @click="handleEditorClick"
+      @focusin="handleEditorFocusin"
+      @focusout="handleEditorFocusout"
       @keydown="handleEditorKeydown"
     />
+
+    <Teleport to="body">
+      <Transition name="scene-prompt-hover-preview">
+        <aside
+          v-if="focusMode && hoverPreviewOption && hoverPreviewSource"
+          class="scene-prompt-hover-preview"
+          :class="`is-${hoverPreviewOption.kind}`"
+          :style="hoverPreviewStyle"
+          role="tooltip"
+          :aria-label="`${hoverPreviewOption.label}预览`"
+        >
+          <video v-if="hoverPreviewOption.kind === 'video'" :src="hoverPreviewSource" muted autoplay loop playsinline preload="metadata" />
+          <img v-else :src="hoverPreviewSource" :alt="hoverPreviewOption.label" />
+          <footer><component :is="hoverPreviewOption.kind === 'video' ? Film : ImageIcon" :size="14" /><strong>{{ hoverPreviewOption.label }}</strong><small>{{ hoverPreviewOption.kind === 'video' ? '视频预览' : '图片预览' }}</small></footer>
+        </aside>
+      </Transition>
+    </Teleport>
 
     <Teleport to="body">
       <Transition name="scene-prompt-menu">
@@ -635,6 +719,14 @@ onBeforeUnmount(() => {
 .scene-prompt-editor__input :deep(.scene-prompt-editor__duration-icon),.scene-prompt-editor__input :deep(.scene-prompt-editor__audio-icon) { display: inline-grid; width: 14px; height: 14px; flex: 0 0 14px; place-items: center; color: currentColor; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__audio-icon) { width: 18px; height: 18px; flex-basis: 18px; border-radius: 6px; color: var(--app-accent); background: color-mix(in srgb,var(--app-accent) 10%,transparent); transition: color .16s ease,background .16s ease,transform .16s ease; }
 .scene-prompt-editor__input :deep(.scene-prompt-editor__mention.is-audio.is-playing .scene-prompt-editor__audio-icon) { color: #fff; background: var(--app-accent); transform: scale(.94); }
+.scene-prompt-hover-preview { position: fixed; z-index: 178; display: grid; width: min(420px,calc(100vw - 24px)); grid-template-rows: minmax(0,280px) 44px; overflow: hidden; border: 1px solid var(--app-border); border-radius: 16px; color: var(--app-text); background: var(--app-surface-raised); box-shadow: 0 24px 70px rgb(12 16 28 / 28%); pointer-events: none; }
+.scene-prompt-hover-preview > img,.scene-prompt-hover-preview > video { display: block; width: 100%; height: 280px; background: #171a21; object-fit: contain; }
+.scene-prompt-hover-preview > footer { display: grid; min-width: 0; grid-template-columns: 18px minmax(0,1fr) auto; align-items: center; gap: 7px; padding: 0 12px; border-top: 1px solid var(--app-border); background: var(--app-surface); }
+.scene-prompt-hover-preview > footer svg { color: var(--app-accent); }
+.scene-prompt-hover-preview > footer strong { overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.scene-prompt-hover-preview > footer small { color: var(--app-text-muted); font-size: 9px; }
+.scene-prompt-hover-preview-enter-active,.scene-prompt-hover-preview-leave-active { transition: opacity .14s ease,transform .16s cubic-bezier(.2,.72,.2,1); transform-origin: center; }
+.scene-prompt-hover-preview-enter-from,.scene-prompt-hover-preview-leave-to { opacity: 0; transform: translateY(4px) scale(.985); }
 .scene-prompt-mentions { position: fixed; z-index: 170; display: grid; width: min(340px,calc(100vw - 24px)); max-height: 340px; grid-template-rows: auto minmax(0,1fr) auto; overflow: hidden; border-radius: 13px; color: var(--app-text-secondary); background: var(--app-surface-raised); box-shadow: var(--app-shadow), inset 0 0 0 1px var(--app-border); backdrop-filter: blur(16px); }
 .scene-prompt-mentions > header { display: flex; min-height: 40px; align-items: center; gap: 7px; padding: 0 11px; border-bottom: 1px solid var(--app-border); }
 .scene-prompt-mentions > header svg { color: var(--app-accent); }
@@ -680,7 +772,8 @@ onBeforeUnmount(() => {
   .scene-prompt-video-preview { padding: 10px; }
   .scene-prompt-video-preview > section { width: calc(100vw - 20px); max-height: calc(100dvh - 20px); }
 }
+@media (hover: none) { .scene-prompt-hover-preview { display: none; } }
 @media (prefers-reduced-motion: reduce) {
-  .scene-prompt-menu-enter-active,.scene-prompt-menu-leave-active,.scene-prompt-preview-enter-active,.scene-prompt-preview-leave-active { transition-duration: .01ms !important; }
+  .scene-prompt-menu-enter-active,.scene-prompt-menu-leave-active,.scene-prompt-preview-enter-active,.scene-prompt-preview-leave-active,.scene-prompt-hover-preview-enter-active,.scene-prompt-hover-preview-leave-active { transition-duration: .01ms !important; }
 }
 </style>

--- a/web/src/components/ScenePromptFocusDialog.spec.ts
+++ b/web/src/components/ScenePromptFocusDialog.spec.ts
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import ScenePromptFocusDialog from './ScenePromptFocusDialog.vue'
+import type { ScenePromptMentionOption } from './ScenePromptEditor.vue'
+
+const options: ScenePromptMentionOption[] = [{
+  id: 'person-1',
+  kind: 'person',
+  label: '林冲',
+  syntax: '@{林冲}',
+  group: '出镜角色',
+}]
+
+afterEach(() => {
+  document.body.style.overflow = ''
+  document.body.innerHTML = ''
+})
+
+function mountDialog(open = false) {
+  return mount(ScenePromptFocusDialog, {
+    props: {
+      open,
+      sceneSequence: 3,
+      modelValue: '镜头跟随 @{林冲} 进入房间',
+      options,
+    },
+    attachTo: document.body,
+    global: {
+      stubs: {
+        Teleport: true,
+        Transition: false,
+      },
+    },
+  })
+}
+
+describe('ScenePromptFocusDialog', () => {
+  it('opens an accessible focus editor and moves keyboard focus into the prompt', async () => {
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    trigger.focus()
+    const wrapper = mountDialog()
+
+    await wrapper.setProps({ open: true })
+    await nextTick()
+
+    const dialog = wrapper.get('[role="dialog"]')
+    const editor = wrapper.get<HTMLElement>('.scene-prompt-editor__input')
+    expect(dialog.attributes('aria-modal')).toBe('true')
+    expect(dialog.text()).toContain('分镜 3 · 专注编辑')
+    expect(document.body.style.overflow).toBe('hidden')
+    expect(document.activeElement).toBe(editor.element)
+  })
+
+  it('edits the same prompt value and reports the updated content to the storyboard', async () => {
+    const wrapper = mountDialog(true)
+    const editor = wrapper.get<HTMLElement>('.scene-prompt-editor__input')
+    editor.element.append(document.createTextNode('，缓慢推进。'))
+    await editor.trigger('input')
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['镜头跟随 @{林冲} 进入房间，缓慢推进。'])
+    expect(wrapper.get('.scene-prompt-focus__footer').text()).toContain('修改自动保存')
+  })
+
+  it('closes with Escape, restores page scrolling and returns focus to the trigger', async () => {
+    const trigger = document.createElement('button')
+    document.body.append(trigger)
+    trigger.focus()
+    const wrapper = mountDialog()
+    await wrapper.setProps({ open: true })
+    await nextTick()
+
+    await wrapper.get('[role="dialog"]').trigger('keydown', { key: 'Escape' })
+    expect(wrapper.emitted('close')).toHaveLength(1)
+
+    await wrapper.setProps({ open: false })
+    await nextTick()
+    expect(document.body.style.overflow).toBe('')
+    expect(document.activeElement).toBe(trigger)
+  })
+})

--- a/web/src/components/ScenePromptFocusDialog.spec.ts
+++ b/web/src/components/ScenePromptFocusDialog.spec.ts
@@ -10,6 +10,7 @@ const options: ScenePromptMentionOption[] = [{
   label: '林冲',
   syntax: '@{林冲}',
   group: '出镜角色',
+  previewUrl: '/media/linchong.png',
 }]
 
 afterEach(() => {
@@ -64,7 +65,7 @@ describe('ScenePromptFocusDialog', () => {
     expect(wrapper.get('.scene-prompt-focus__footer').text()).toContain('修改自动保存')
   })
 
-  it('closes with Escape, restores page scrolling and returns focus to the trigger', async () => {
+  it('closes with Escape from the editor, restores page scrolling and returns focus to the trigger', async () => {
     const trigger = document.createElement('button')
     document.body.append(trigger)
     trigger.focus()
@@ -72,12 +73,38 @@ describe('ScenePromptFocusDialog', () => {
     await wrapper.setProps({ open: true })
     await nextTick()
 
-    await wrapper.get('[role="dialog"]').trigger('keydown', { key: 'Escape' })
+    await wrapper.get('.scene-prompt-editor__input').trigger('keydown', { key: 'Escape' })
+    await nextTick()
     expect(wrapper.emitted('close')).toHaveLength(1)
 
     await wrapper.setProps({ open: false })
     await nextTick()
     expect(document.body.style.overflow).toBe('')
     expect(document.activeElement).toBe(trigger)
+  })
+
+  it('closes with Escape even when focus has moved outside the dialog content', async () => {
+    const wrapper = mountDialog(true)
+    document.body.focus()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('uses the first Escape to close a nested media preview and the second to exit focus mode', async () => {
+    const wrapper = mountDialog(true)
+    await wrapper.get('.scene-prompt-editor__mention').trigger('click')
+    expect(wrapper.find('[aria-label="图片放大查看"]').exists()).toBe(true)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    await nextTick()
+    expect(wrapper.emitted('close')).toBeUndefined()
+    expect(wrapper.find('[aria-label="图片放大查看"]').exists()).toBe(false)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    await nextTick()
+    expect(wrapper.emitted('close')).toHaveLength(1)
   })
 })

--- a/web/src/components/ScenePromptFocusDialog.spec.ts
+++ b/web/src/components/ScenePromptFocusDialog.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import ScenePromptFocusDialog from './ScenePromptFocusDialog.vue'
 import type { ScenePromptMentionOption } from './ScenePromptEditor.vue'
@@ -14,6 +14,7 @@ const options: ScenePromptMentionOption[] = [{
 }]
 
 afterEach(() => {
+  vi.restoreAllMocks()
   document.body.style.overflow = ''
   document.body.innerHTML = ''
 })
@@ -91,6 +92,48 @@ describe('ScenePromptFocusDialog', () => {
     await nextTick()
 
     expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('also closes on Escape keyup when Chrome consumes the editor keydown', async () => {
+    const wrapper = mountDialog(true)
+
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true, cancelable: true }))
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('accepts the legacy Esc key value emitted by some Chrome input states', async () => {
+    const wrapper = mountDialog(true)
+
+    await wrapper.get('.scene-prompt-editor__input').trigger('keydown', { key: 'Esc' })
+    await nextTick()
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('exits when Chrome consumes Escape and only blurs the contenteditable to the page body', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    const wrapper = mountDialog(true)
+    await nextTick()
+    document.body.tabIndex = -1
+    document.body.focus()
+    await new Promise(resolve => window.setTimeout(resolve))
+
+    expect(document.activeElement).toBe(document.body)
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('does not exit when a pointer interaction inside the dialog blurs the editor', async () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    const wrapper = mountDialog(true)
+    await nextTick()
+    await wrapper.get('[role="dialog"]').trigger('pointerdown')
+    document.body.tabIndex = -1
+    document.body.focus()
+    await new Promise(resolve => window.setTimeout(resolve))
+
+    expect(wrapper.emitted('close')).toBeUndefined()
   })
 
   it('exits focus mode with one Escape even when a nested media preview is open', async () => {

--- a/web/src/components/ScenePromptFocusDialog.spec.ts
+++ b/web/src/components/ScenePromptFocusDialog.spec.ts
@@ -93,15 +93,10 @@ describe('ScenePromptFocusDialog', () => {
     expect(wrapper.emitted('close')).toHaveLength(1)
   })
 
-  it('uses the first Escape to close a nested media preview and the second to exit focus mode', async () => {
+  it('exits focus mode with one Escape even when a nested media preview is open', async () => {
     const wrapper = mountDialog(true)
     await wrapper.get('.scene-prompt-editor__mention').trigger('click')
     expect(wrapper.find('[aria-label="图片放大查看"]').exists()).toBe(true)
-
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
-    await nextTick()
-    expect(wrapper.emitted('close')).toBeUndefined()
-    expect(wrapper.find('[aria-label="图片放大查看"]').exists()).toBe(false)
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
     await nextTick()

--- a/web/src/components/ScenePromptFocusDialog.spec.ts
+++ b/web/src/components/ScenePromptFocusDialog.spec.ts
@@ -49,6 +49,7 @@ describe('ScenePromptFocusDialog', () => {
     const editor = wrapper.get<HTMLElement>('.scene-prompt-editor__input')
     expect(dialog.attributes('aria-modal')).toBe('true')
     expect(dialog.text()).toContain('分镜 3 · 专注编辑')
+    expect(wrapper.find('.scene-prompt-focus__footer button').exists()).toBe(false)
     expect(document.body.style.overflow).toBe('hidden')
     expect(document.activeElement).toBe(editor.element)
   })

--- a/web/src/components/ScenePromptFocusDialog.vue
+++ b/web/src/components/ScenePromptFocusDialog.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { Focus, X } from 'lucide-vue-next'
+import AppButton from './AppButton.vue'
+import ScenePromptEditor, { type ScenePromptMentionOption } from './ScenePromptEditor.vue'
+
+const props = withDefaults(defineProps<{
+  open: boolean
+  sceneSequence: number
+  modelValue: string
+  options: ScenePromptMentionOption[]
+  placeholder?: string
+}>(), {
+  placeholder: '请输入分镜视频提示词。描述镜头、主体动作、运镜、光线、画面风格和声音。',
+})
+
+const emit = defineEmits<{
+  close: []
+  'update:modelValue': [value: string]
+}>()
+
+const dialog = ref<HTMLElement | null>(null)
+let previousActiveElement: HTMLElement | null = null
+let previousBodyOverflow = ''
+
+function close() {
+  emit('close')
+}
+
+function focusableElements() {
+  if (!dialog.value) return []
+  return [...dialog.value.querySelectorAll<HTMLElement>([
+    'button:not([disabled])',
+    'a[href]',
+    'input:not([disabled])',
+    'textarea:not([disabled])',
+    'select:not([disabled])',
+    '[contenteditable="true"]',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(','))].filter(element => element.getAttribute('aria-hidden') !== 'true')
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    if (event.defaultPrevented) return
+    event.preventDefault()
+    close()
+    return
+  }
+  if (event.key !== 'Tab') return
+  const elements = focusableElements()
+  if (!elements.length) {
+    event.preventDefault()
+    dialog.value?.focus()
+    return
+  }
+  const first = elements[0]!
+  const last = elements.at(-1)!
+  const active = document.activeElement
+  if (event.shiftKey && (active === first || !dialog.value?.contains(active))) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && (active === last || !dialog.value?.contains(active))) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+watch(() => props.open, async open => {
+  if (open) {
+    previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    previousBodyOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    await nextTick()
+    dialog.value?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
+    return
+  }
+  document.body.style.overflow = previousBodyOverflow
+  await nextTick()
+  previousActiveElement?.focus()
+  previousActiveElement = null
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  document.body.style.overflow = previousBodyOverflow
+  previousActiveElement?.focus()
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="scene-prompt-focus">
+      <div v-if="open" class="scene-prompt-focus__backdrop" @pointerdown.self="close">
+        <section
+          ref="dialog"
+          class="scene-prompt-focus"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="scene-prompt-focus-title"
+          tabindex="-1"
+          @keydown="handleKeydown"
+        >
+          <header class="scene-prompt-focus__header">
+            <span class="scene-prompt-focus__icon"><Focus :size="19" /></span>
+            <div>
+              <span>FOCUS MODE</span>
+              <h2 id="scene-prompt-focus-title">分镜 {{ sceneSequence }} · 专注编辑</h2>
+            </div>
+            <kbd>Esc</kbd>
+            <AppButton type="button" variant="ghost" size="sm" icon-only aria-label="退出专注编辑" title="退出专注编辑" @click="close"><X :size="18" /></AppButton>
+          </header>
+
+          <main class="scene-prompt-focus__body">
+            <ScenePromptEditor
+              :model-value="modelValue"
+              :options="options"
+              :placeholder="placeholder"
+              focus-mode
+              @update:model-value="emit('update:modelValue', $event)"
+            />
+          </main>
+
+          <footer class="scene-prompt-focus__footer">
+            <span>输入 <kbd>@</kbd> 可继续引用角色、场景、道具与素材</span>
+            <span>{{ modelValue.length.toLocaleString() }} 字符 · 修改自动保存</span>
+            <AppButton type="button" variant="primary" size="sm" @click="close">完成编辑</AppButton>
+          </footer>
+        </section>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.scene-prompt-focus__backdrop { position: fixed; inset: 0; z-index: 160; display: grid; place-items: center; padding: 28px; background: rgb(24 27 38 / 58%); backdrop-filter: blur(12px); }
+.scene-prompt-focus { display: grid; width: min(1180px,100%); height: min(840px,calc(100dvh - 56px)); min-height: 460px; grid-template-rows: auto minmax(0,1fr) auto; overflow: hidden; border: 1px solid color-mix(in srgb,var(--app-border) 86%,transparent); border-radius: 22px; outline: 0; color: var(--app-text); background: var(--app-surface); box-shadow: 0 40px 120px rgb(12 16 30 / 36%); }
+.scene-prompt-focus__header { display: grid; min-height: 78px; grid-template-columns: 44px minmax(0,1fr) auto 34px; align-items: center; gap: 12px; padding: 12px 18px; border-bottom: 1px solid var(--app-border); background: linear-gradient(135deg,color-mix(in srgb,var(--app-surface) 94%,var(--app-accent)),var(--app-surface)); }
+.scene-prompt-focus__icon { display: grid; width: 44px; height: 44px; place-items: center; border-radius: 14px; color: var(--app-accent); background: var(--app-surface); box-shadow: inset 0 0 0 1px var(--app-border),0 8px 22px rgb(72 75 160 / 10%); }
+.scene-prompt-focus__header > div { min-width: 0; }
+.scene-prompt-focus__header > div > span { color: var(--app-accent); font-size: 8px; font-weight: 800; letter-spacing: .14em; }
+.scene-prompt-focus__header h2 { margin: 4px 0 0; overflow: hidden; font-size: 18px; line-height: 1.2; text-overflow: ellipsis; white-space: nowrap; }
+.scene-prompt-focus__header > kbd { padding: 4px 7px; border-radius: 6px; color: var(--app-text-muted); background: var(--app-surface-muted); box-shadow: inset 0 0 0 1px var(--app-border); font: inherit; font-size: 9px; }
+.scene-prompt-focus__body { min-height: 0; overflow: hidden; padding: 14px 18px; background: color-mix(in srgb,var(--app-surface-muted) 72%,var(--app-surface)); }
+.scene-prompt-focus__body :deep(.scene-prompt-editor) { border-radius: 15px; background: var(--app-surface); box-shadow: inset 0 0 0 1px var(--app-border),0 10px 30px rgb(22 27 45 / 4%); }
+.scene-prompt-focus__body :deep(.scene-prompt-editor:focus-within) { box-shadow: inset 0 0 0 1px color-mix(in srgb,var(--app-accent) 48%,var(--app-border)),0 0 0 3px color-mix(in srgb,var(--app-accent) 8%,transparent); }
+.scene-prompt-focus__footer { display: grid; min-height: 66px; grid-template-columns: minmax(0,1fr) auto auto; align-items: center; gap: 18px; padding: 10px 18px; border-top: 1px solid var(--app-border); color: var(--app-text-muted); background: var(--app-surface); font-size: 10px; }
+.scene-prompt-focus__footer > span:first-child { color: var(--app-text-secondary); }
+.scene-prompt-focus__footer kbd { padding: 2px 5px; border-radius: 5px; color: var(--app-accent); background: var(--app-accent-soft); box-shadow: inset 0 0 0 1px var(--app-border); font: inherit; font-weight: 750; }
+.scene-prompt-focus-enter-active,.scene-prompt-focus-leave-active { transition: opacity .2s ease; }
+.scene-prompt-focus-enter-active .scene-prompt-focus,.scene-prompt-focus-leave-active .scene-prompt-focus { transition: transform .24s cubic-bezier(.2,.72,.2,1),opacity .2s ease; }
+.scene-prompt-focus-enter-from,.scene-prompt-focus-leave-to { opacity: 0; }
+.scene-prompt-focus-enter-from .scene-prompt-focus,.scene-prompt-focus-leave-to .scene-prompt-focus { opacity: 0; transform: translateY(10px) scale(.985); }
+@media (max-width: 720px) {
+  .scene-prompt-focus__backdrop { padding: 8px; }
+  .scene-prompt-focus { width: 100%; height: calc(100dvh - 16px); min-height: 0; border-radius: 17px; }
+  .scene-prompt-focus__header { min-height: 68px; grid-template-columns: 38px minmax(0,1fr) 34px; padding: 10px 12px; }
+  .scene-prompt-focus__icon { width: 38px; height: 38px; border-radius: 12px; }
+  .scene-prompt-focus__header > kbd { display: none; }
+  .scene-prompt-focus__header h2 { font-size: 16px; }
+  .scene-prompt-focus__body { padding: 8px; }
+  .scene-prompt-focus__body :deep(.scene-prompt-editor__input) { padding: 18px 16px 32px; font-size: 13px; }
+  .scene-prompt-focus__footer { min-height: 58px; grid-template-columns: minmax(0,1fr) auto; gap: 10px; padding: 8px 10px; }
+  .scene-prompt-focus__footer > span:first-child { display: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .scene-prompt-focus-enter-active,.scene-prompt-focus-leave-active,.scene-prompt-focus-enter-active .scene-prompt-focus,.scene-prompt-focus-leave-active .scene-prompt-focus { transition-duration: .01ms; }
+}
+</style>

--- a/web/src/components/ScenePromptFocusDialog.vue
+++ b/web/src/components/ScenePromptFocusDialog.vue
@@ -123,7 +123,6 @@ onBeforeUnmount(() => {
           <footer class="scene-prompt-focus__footer">
             <span>输入 <kbd>@</kbd> 可继续引用角色、场景、道具与素材</span>
             <span>{{ modelValue.length.toLocaleString() }} 字符 · 修改自动保存</span>
-            <AppButton type="button" variant="primary" size="sm" @click="close">完成编辑</AppButton>
           </footer>
         </section>
       </div>
@@ -143,7 +142,7 @@ onBeforeUnmount(() => {
 .scene-prompt-focus__body { min-height: 0; overflow: hidden; padding: 14px 18px; background: color-mix(in srgb,var(--app-surface-muted) 72%,var(--app-surface)); }
 .scene-prompt-focus__body :deep(.scene-prompt-editor) { border-radius: 15px; background: var(--app-surface); box-shadow: inset 0 0 0 1px var(--app-border),0 10px 30px rgb(22 27 45 / 4%); }
 .scene-prompt-focus__body :deep(.scene-prompt-editor:focus-within) { box-shadow: inset 0 0 0 1px color-mix(in srgb,var(--app-accent) 48%,var(--app-border)),0 0 0 3px color-mix(in srgb,var(--app-accent) 8%,transparent); }
-.scene-prompt-focus__footer { display: grid; min-height: 66px; grid-template-columns: minmax(0,1fr) auto auto; align-items: center; gap: 18px; padding: 10px 18px; border-top: 1px solid var(--app-border); color: var(--app-text-muted); background: var(--app-surface); font-size: 10px; }
+.scene-prompt-focus__footer { display: grid; min-height: 66px; grid-template-columns: minmax(0,1fr) auto; align-items: center; gap: 18px; padding: 10px 18px; border-top: 1px solid var(--app-border); color: var(--app-text-muted); background: var(--app-surface); font-size: 10px; }
 .scene-prompt-focus__footer > span:first-child { color: var(--app-text-secondary); }
 .scene-prompt-focus__footer kbd { padding: 2px 5px; border-radius: 5px; color: var(--app-accent); background: var(--app-accent-soft); box-shadow: inset 0 0 0 1px var(--app-border); font: inherit; font-weight: 750; }
 .scene-prompt-focus-enter-active,.scene-prompt-focus-leave-active { transition: opacity .2s ease; }
@@ -159,8 +158,9 @@ onBeforeUnmount(() => {
   .scene-prompt-focus__header h2 { font-size: 16px; }
   .scene-prompt-focus__body { padding: 8px; }
   .scene-prompt-focus__body :deep(.scene-prompt-editor__input) { padding: 18px 16px 32px; font-size: 13px; }
-  .scene-prompt-focus__footer { min-height: 58px; grid-template-columns: minmax(0,1fr) auto; gap: 10px; padding: 8px 10px; }
+  .scene-prompt-focus__footer { min-height: 58px; grid-template-columns: 1fr; gap: 10px; padding: 8px 10px; }
   .scene-prompt-focus__footer > span:first-child { display: none; }
+  .scene-prompt-focus__footer > span:last-child { justify-self: end; }
 }
 @media (prefers-reduced-motion: reduce) {
   .scene-prompt-focus-enter-active,.scene-prompt-focus-leave-active,.scene-prompt-focus-enter-active .scene-prompt-focus,.scene-prompt-focus-leave-active .scene-prompt-focus { transition-duration: .01ms; }

--- a/web/src/components/ScenePromptFocusDialog.vue
+++ b/web/src/components/ScenePromptFocusDialog.vue
@@ -22,6 +22,8 @@ const emit = defineEmits<{
 const dialog = ref<HTMLElement | null>(null)
 let previousActiveElement: HTMLElement | null = null
 let previousBodyOverflow = ''
+let escapeCloseRequested = false
+let lastDialogPointerdownAt = 0
 
 function close() {
   emit('close')
@@ -40,7 +42,38 @@ function focusableElements() {
   ].join(','))].filter(element => element.getAttribute('aria-hidden') !== 'true')
 }
 
+function isEscapeKey(event: KeyboardEvent) {
+  return event.key === 'Escape' || event.key === 'Esc' || event.code === 'Escape' || event.keyCode === 27
+}
+
+function closeFromEscape(event: KeyboardEvent) {
+  if (!props.open || escapeCloseRequested) return
+  escapeCloseRequested = true
+  event.preventDefault()
+  event.stopPropagation()
+  close()
+}
+
+function handleDialogPointerdown() {
+  lastDialogPointerdownAt = performance.now()
+}
+
+function handleDialogFocusout() {
+  window.setTimeout(() => {
+    if (!props.open || escapeCloseRequested || !document.hasFocus()) return
+    if (dialog.value?.contains(document.activeElement)) return
+    if (performance.now() - lastDialogPointerdownAt < 250) return
+    if (document.activeElement !== document.body) return
+    escapeCloseRequested = true
+    close()
+  })
+}
+
 function handleKeydown(event: KeyboardEvent) {
+  if (isEscapeKey(event)) {
+    closeFromEscape(event)
+    return
+  }
   if (event.key !== 'Tab') return
   const elements = focusableElements()
   if (!elements.length) {
@@ -60,16 +93,25 @@ function handleKeydown(event: KeyboardEvent) {
   }
 }
 
-function handleWindowKeydown(event: KeyboardEvent) {
-  if (event.key !== 'Escape' || !props.open) return
-  event.preventDefault()
-  event.stopPropagation()
-  close()
+function handleWindowEscape(event: KeyboardEvent) {
+  if (isEscapeKey(event)) closeFromEscape(event)
+}
+
+function addEscapeListeners() {
+  window.addEventListener('keydown', handleWindowEscape, true)
+  window.addEventListener('keyup', handleWindowEscape, true)
+}
+
+function removeEscapeListeners() {
+  window.removeEventListener('keydown', handleWindowEscape, true)
+  window.removeEventListener('keyup', handleWindowEscape, true)
 }
 
 watch(() => props.open, async open => {
   if (open) {
-    window.addEventListener('keydown', handleWindowKeydown, true)
+    escapeCloseRequested = false
+    lastDialogPointerdownAt = 0
+    addEscapeListeners()
     previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
     previousBodyOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
@@ -77,7 +119,7 @@ watch(() => props.open, async open => {
     dialog.value?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
     return
   }
-  window.removeEventListener('keydown', handleWindowKeydown, true)
+  removeEscapeListeners()
   document.body.style.overflow = previousBodyOverflow
   await nextTick()
   previousActiveElement?.focus()
@@ -85,7 +127,7 @@ watch(() => props.open, async open => {
 }, { immediate: true })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('keydown', handleWindowKeydown, true)
+  removeEscapeListeners()
   document.body.style.overflow = previousBodyOverflow
   previousActiveElement?.focus()
 })
@@ -102,7 +144,9 @@ onBeforeUnmount(() => {
           aria-modal="true"
           aria-labelledby="scene-prompt-focus-title"
           tabindex="-1"
+          @focusout="handleDialogFocusout"
           @keydown="handleKeydown"
+          @pointerdown="handleDialogPointerdown"
         >
           <header class="scene-prompt-focus__header">
             <span class="scene-prompt-focus__icon"><Focus :size="19" /></span>

--- a/web/src/components/ScenePromptFocusDialog.vue
+++ b/web/src/components/ScenePromptFocusDialog.vue
@@ -20,7 +20,6 @@ const emit = defineEmits<{
 }>()
 
 const dialog = ref<HTMLElement | null>(null)
-const promptEditor = ref<InstanceType<typeof ScenePromptEditor> | null>(null)
 let previousActiveElement: HTMLElement | null = null
 let previousBodyOverflow = ''
 
@@ -65,7 +64,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
   if (event.key !== 'Escape' || !props.open) return
   event.preventDefault()
   event.stopPropagation()
-  if (promptEditor.value?.consumeEscape()) return
   close()
 }
 
@@ -118,7 +116,6 @@ onBeforeUnmount(() => {
 
           <main class="scene-prompt-focus__body">
             <ScenePromptEditor
-              ref="promptEditor"
               :model-value="modelValue"
               :options="options"
               :placeholder="placeholder"

--- a/web/src/components/ScenePromptFocusDialog.vue
+++ b/web/src/components/ScenePromptFocusDialog.vue
@@ -20,6 +20,7 @@ const emit = defineEmits<{
 }>()
 
 const dialog = ref<HTMLElement | null>(null)
+const promptEditor = ref<InstanceType<typeof ScenePromptEditor> | null>(null)
 let previousActiveElement: HTMLElement | null = null
 let previousBodyOverflow = ''
 
@@ -41,12 +42,6 @@ function focusableElements() {
 }
 
 function handleKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape') {
-    if (event.defaultPrevented) return
-    event.preventDefault()
-    close()
-    return
-  }
   if (event.key !== 'Tab') return
   const elements = focusableElements()
   if (!elements.length) {
@@ -66,8 +61,17 @@ function handleKeydown(event: KeyboardEvent) {
   }
 }
 
+function handleWindowKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Escape' || !props.open) return
+  event.preventDefault()
+  event.stopPropagation()
+  if (promptEditor.value?.consumeEscape()) return
+  close()
+}
+
 watch(() => props.open, async open => {
   if (open) {
+    window.addEventListener('keydown', handleWindowKeydown, true)
     previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
     previousBodyOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
@@ -75,6 +79,7 @@ watch(() => props.open, async open => {
     dialog.value?.querySelector<HTMLElement>('[contenteditable="true"]')?.focus()
     return
   }
+  window.removeEventListener('keydown', handleWindowKeydown, true)
   document.body.style.overflow = previousBodyOverflow
   await nextTick()
   previousActiveElement?.focus()
@@ -82,6 +87,7 @@ watch(() => props.open, async open => {
 }, { immediate: true })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleWindowKeydown, true)
   document.body.style.overflow = previousBodyOverflow
   previousActiveElement?.focus()
 })
@@ -112,6 +118,7 @@ onBeforeUnmount(() => {
 
           <main class="scene-prompt-focus__body">
             <ScenePromptEditor
+              ref="promptEditor"
               :model-value="modelValue"
               :options="options"
               :placeholder="placeholder"

--- a/web/src/pages/ShortDramaStoryboardPage.vue
+++ b/web/src/pages/ShortDramaStoryboardPage.vue
@@ -8,6 +8,7 @@ import {
   GripVertical,
   ImageIcon,
   LoaderCircle,
+  Maximize2,
   MonitorPlay,
   PanelsTopLeft,
   Plus,
@@ -27,6 +28,7 @@ import ChapterDetailDrawer from '@/components/ChapterDetailDrawer.vue'
 import SceneAssetActionMenu from '@/components/SceneAssetActionMenu.vue'
 import SceneAssetVariantPicker, { type SceneAssetVariantSelection } from '@/components/SceneAssetVariantPicker.vue'
 import ScenePromptEditor, { type ScenePromptMentionOption } from '@/components/ScenePromptEditor.vue'
+import ScenePromptFocusDialog from '@/components/ScenePromptFocusDialog.vue'
 import SceneReferenceMediaBar from '@/components/SceneReferenceMediaBar.vue'
 import SceneVideoParameterPicker from '@/components/SceneVideoParameterPicker.vue'
 import ShortDramaBatchVideoDialog, { type BatchVideoGenerationRequest, type BatchVideoSceneOption } from '@/components/ShortDramaBatchVideoDialog.vue'
@@ -120,6 +122,7 @@ const refreshingVideoHistorySceneIds = ref<Set<number>>(new Set())
 const generationErrors = ref<Record<number, string>>({})
 const videoGenerationErrors = ref<Record<number, string>>({})
 const sceneDrafts = ref<Record<number, SceneDraft>>({})
+const focusedPromptSceneId = ref(0)
 const highlightedReferenceKey = ref('')
 const openAssetPickerKey = ref('')
 const assetPickerFocusIds = ref<Record<string, number>>({})
@@ -329,6 +332,10 @@ function draftFor(scene: Scene) {
   if (!sceneDrafts.value[scene.id]) sceneDrafts.value[scene.id] = makeSceneDraft(scene)
   return sceneDrafts.value[scene.id]
 }
+
+const focusedPromptScene = computed(() => scenes.value.find(scene => scene.id === focusedPromptSceneId.value) || null)
+const focusedPromptValue = computed(() => focusedPromptScene.value ? draftFor(focusedPromptScene.value).prompt : '')
+const focusedPromptOptions = computed(() => focusedPromptScene.value ? promptMentionOptions(focusedPromptScene.value) : [])
 
 function initializeSceneDrafts(items: Scene[]) {
   sceneDrafts.value = Object.fromEntries(items.map(scene => [scene.id, makeSceneDraft(scene)]))
@@ -1094,6 +1101,7 @@ async function fetchChapterScenes(chapterId: number) {
 }
 
 function showChapterScenes(result: Awaited<ReturnType<typeof fetchChapterScenes>>) {
+  focusedPromptSceneId.value = 0
   activeChapter.value = result.chapter
   assets.value = result.assets
   scenes.value = result.scenes
@@ -1290,6 +1298,7 @@ async function regenerateStoryboard() {
 
 async function loadChapter(chapterId: number) {
   const loadVersion = ++chapterLoadVersion
+  focusedPromptSceneId.value = 0
   activeChapterId.value = chapterId
   activeChapter.value = chapters.value.find(item => item.id === chapterId) ?? null
   scenes.value = []
@@ -1430,6 +1439,7 @@ function setupChapterToolbarObserver() {
 async function selectChapter(chapter: Chapter) {
   if (chapter.id === activeChapterId.value) return
   chapterDetailOpen.value = false
+  focusedPromptSceneId.value = 0
   await flushPendingSceneSaves()
   await router.replace({ query: { ...route.query, chapter: String(chapter.id) } })
   await loadChapter(chapter.id)
@@ -1463,6 +1473,19 @@ function updateSceneText(scene: Scene, field: 'description' | 'prompt', event: E
 function updateScenePrompt(scene: Scene, value: string) {
   draftFor(scene).prompt = value
   scheduleSceneSave(scene)
+}
+
+function openPromptFocus(scene: Scene) {
+  activeSceneId.value = scene.id
+  focusedPromptSceneId.value = scene.id
+}
+
+function closePromptFocus() {
+  focusedPromptSceneId.value = 0
+}
+
+function updateFocusedPrompt(value: string) {
+  if (focusedPromptScene.value) updateScenePrompt(focusedPromptScene.value, value)
 }
 
 function updateSceneDraft<K extends keyof SceneDraft>(scene: Scene, field: K, value: SceneDraft[K]) {
@@ -1588,6 +1611,7 @@ async function removeScene(scene: Scene) {
     tone: 'danger',
   })) return
   try {
+    if (focusedPromptSceneId.value === scene.id) closePromptFocus()
     await api.deleteScene(scene.id)
     scenes.value = scenes.value.filter(item => item.id !== scene.id)
     delete sceneDrafts.value[scene.id]
@@ -2009,7 +2033,18 @@ onBeforeUnmount(() => {
               </aside>
 
               <section class="prompt-panel" :class="{ 'has-keyframes': draftFor(scene).videoGenerationMode === 'keyframes' }">
-                <header><div><span><strong>分镜视频生成</strong><small>组合角色、场景和动作，生成连续镜头</small></span></div></header>
+                <header>
+                  <div><span><strong>分镜视频生成</strong><small>组合角色、场景和动作，生成连续镜头</small></span></div>
+                  <AppButton
+                    variant="ghost"
+                    size="sm"
+                    icon-only
+                    class="prompt-focus-trigger"
+                    :aria-label="`放大编辑分镜 ${scene.sequence} 提示词`"
+                    title="专注编辑"
+                    @click="openPromptFocus(scene)"
+                  ><Maximize2 :size="16" /></AppButton>
+                </header>
                 <div v-if="draftFor(scene).videoGenerationMode === 'keyframes'" class="keyframe-inputs">
                   <label :class="{ 'has-image': draftFor(scene).firstFrameUrl }"><input type="file" accept="image/png,image/jpeg,image/webp" @change="uploadFrame(scene, 'first', $event)" /><img v-if="draftFor(scene).firstFrameUrl" :src="draftFor(scene).firstFrameUrl" alt="首帧" /><span v-else><LoaderCircle v-if="uploadingFrameKey === `${scene.id}:first`" :size="18" /><Upload v-else :size="18" /><strong>上传首帧</strong><small>视频开始画面</small></span><i>首帧</i></label>
                   <span>→</span>
@@ -2117,6 +2152,14 @@ onBeforeUnmount(() => {
       @close="closeAssetVoicePicker"
       @choose="selectAssetVoiceReference"
     />
+    <ScenePromptFocusDialog
+      :open="Boolean(focusedPromptScene)"
+      :scene-sequence="focusedPromptScene?.sequence || 0"
+      :model-value="focusedPromptValue"
+      :options="focusedPromptOptions"
+      @close="closePromptFocus"
+      @update:model-value="updateFocusedPrompt"
+    />
   </main>
 </template>
 
@@ -2216,6 +2259,8 @@ onBeforeUnmount(() => {
 .prompt-panel > header > div { display: flex; min-width: 0; align-items: center; gap: 10px; color: var(--app-text); }
 .prompt-panel > header span { display: grid; min-width: 0; gap: 3px; }
 .prompt-panel > header small { color: var(--app-text-muted); font-size: 9px; font-weight: 400; }
+.prompt-focus-trigger { color: var(--app-text-muted); background: var(--app-surface-muted); box-shadow: inset 0 0 0 1px var(--app-border); }
+.prompt-focus-trigger:hover:not(:disabled) { color: var(--app-accent); background: var(--app-accent-soft); box-shadow: inset 0 0 0 1px color-mix(in srgb,var(--app-accent) 24%,var(--app-border)); }
 .keyframe-inputs { display: grid; grid-template-columns: minmax(0,1fr) auto minmax(0,1fr); align-items: center; gap: 10px; padding: 0 16px 14px; }
 .keyframe-inputs > span { color: #a0a5b2; font-size: 16px; }
 .keyframe-inputs label { position: relative; display: grid; min-height: 112px; overflow: hidden; place-items: center; border-radius: 12px; color: #858b9a; background: #f7f8fb; box-shadow: inset 0 0 0 1px #e8eaf1; cursor: pointer; }


### PR DESCRIPTION
## 变更
- 为所有分镜提示词增加专注编辑弹窗
- 支持素材图片与视频悬浮纯画面预览，并按标签上下居中
- 修复 Chrome 中一次 Esc 退出专注模式
- 保留自动保存、键盘焦点管理与响应式布局

## 验证
- 前端完整测试：444 项通过
- TypeScript 类型检查通过
- 生产构建通过
- Chrome 实测输入框、素材预览和空白区域均可一次 Esc 退出