### PR TITLE
fix(media): serve WebP previews with the correct content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ OSS_ACCESS_KEY_SECRET=
 项目封面会保留原图，并自动生成列表缩略图与详情预览图。升级已有环境后，执行一次幂等回填：
 
 ```bash
-uv run python scripts/backfill_media_derivatives.py
+uv run python -m scripts.backfill_media_derivatives
 ```
 
 本地媒体会在原图旁生成 WebP 派生图；OSS 模式通过 `OSS_INTERNAL_ENDPOINT` 读写，并为派生图设置长期不可变缓存。该命令也会为设定资产图片生成缩略图，并为历史生成视频提取首帧海报。

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from exceptions.handlers import (
 )
 from exceptions.remake import RemakeError, remake_exception_handler
 from services.ai_task_executor import ai_task_executor
+from services.media_types import register_media_mime_types
 from services.extraction.handler import ExtractionTaskHandler
 from services.reference.handler import AssetReferenceHandler
 from services.project_analysis.handler import ProjectAnalysisTaskHandler
@@ -177,6 +178,7 @@ ai_task_executor.register(
 
 
 # 为媒体（图像、视频、音频）安装静态文件
+register_media_mime_types()
 media_path = Path(settings.MEDIA_PATH)
 media_path.mkdir(parents=True, exist_ok=True)
 app.mount("/media", StaticFiles(directory=str(media_path)), name="media")

--- a/services/media_types.py
+++ b/services/media_types.py
@@ -1,0 +1,11 @@
+"""注册精简运行镜像中可能缺失的媒体 MIME 类型。"""
+
+from __future__ import annotations
+
+import mimetypes
+
+
+def register_media_mime_types() -> None:
+    """确保浏览器可在 ``nosniff`` 策略下正确识别衍生媒体。"""
+
+    mimetypes.add_type("image/webp", ".webp", strict=True)

--- a/test/test_services/test_media_types.py
+++ b/test/test_services/test_media_types.py
@@ -1,0 +1,31 @@
+import mimetypes
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+from services.media_types import register_media_mime_types
+
+
+@pytest.mark.asyncio
+async def test_webp_static_file_uses_image_content_type_in_minimal_runtime(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delitem(mimetypes.types_map, ".webp", raising=False)
+    register_media_mime_types()
+    assert mimetypes.guess_type("thumbnail.webp")[0] == "image/webp"
+
+    (tmp_path / "thumbnail.webp").write_bytes(b"webp")
+    app = FastAPI()
+    app.mount("/media", StaticFiles(directory=tmp_path), name="media")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="https://test",
+    ) as client:
+        response = await client.get("/media/thumbnail.webp")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/webp"


### PR DESCRIPTION
## 修复内容

- 在应用启动时显式注册 image/webp MIME 类型
- 修复精简运行镜像把 WebP 缩略图返回为 text/plain 的问题
- 保证 X-Content-Type-Options: nosniff 下浏览器仍可正常显示预览图
- 修正历史媒体补齐脚本的 README 调用方式

## 验证

- 新增精简运行环境 MIME 回归测试
- 安全响应头测试通过
- 后端完整测试通过
- git diff --check 通过