### PR TITLE
feat(demo): display supported model catalog

### DIFF
--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -5,7 +5,8 @@
 ## 安全边界
 
 - 演示数据库只保留显式项目白名单，并重建为单一查看者、零团队余额、零个人额度。
-- 原账号、会话、邀请、账单、供应商任务 ID、模型配置和非展示 AI 任务全部移除。
+- 原账号、会话、邀请、账单、供应商任务 ID、真实模型配置和非展示 AI 任务全部移除；
+  快照仅重建无密钥、不可调用的支持模型目录，供查看者在工作台浏览全部模型能力。
 - 每个入选项目仅保留最新一条已完成的项目分析展示结果；任务请求参数缩减为
   `novel_id`，其余 AI 任务、错误和执行阶段全部移除。
 - 媒体只复制保留项目实际引用的文件；远程 HTTPS 媒体可在导出时本地化，运行时固定 `OSS_PROVIDER=local`。
@@ -18,7 +19,7 @@
 在仓库根目录执行，项目 ID 必须逐个显式选择：
 
 ```bash
-uv run python scripts/create_demo_snapshot.py \
+uv run python -m scripts.create_demo_snapshot \
   --source-db data/novelvids.db \
   --source-media media \
   --output-dir demo_seed \
@@ -72,6 +73,8 @@ npm run build
 - 公网仅由受控反向代理接入，Compose 端口保持 `127.0.0.1:18080`；若启用边缘 WAF，再将源站限制为该供应商的回源地址。
 - `demo` 登录后 `/api/auth/me` 的角色必须是 `viewer`，余额和限额都为 0。
 - 项目列表、设定、分镜和媒体均可读；项目创建和模型配置接口返回业务码 403。
+- 生图与视频模型下拉框应覆盖后台枚举中的全部支持类型；目录项密钥为空、地址固定为
+  `disabled://demo-model-catalog`，切换模型只用于查看比例、分辨率与多模态能力差异。
 - `/docs` 与 `/openapi.json` 在演示站可用；商业站不可用。
 - 容器内没有 `.env`、模型 Key 或 OSS 凭据，数据库中不存在 HTTP/OSS 媒体引用。
 - 手工修改演示密码或数据后执行重置，确认恢复黄金状态。

--- a/scripts/create_demo_snapshot.py
+++ b/scripts/create_demo_snapshot.py
@@ -2,7 +2,8 @@
 """从本地 SQLite 安全制作可每日恢复的只读演示快照。
 
 脚本只接受显式项目 ID，使用 SQLite backup API 获取一致性副本，再移除账号、
-会话、账单、模型配置和未选项目。媒体目录仅复制保留数据实际引用的本地文件。
+会话、账单、真实模型配置和未选项目。演示库只重建无密钥、不可调用的模型能力
+目录，媒体目录仅复制保留数据实际引用的本地文件。
 """
 
 from __future__ import annotations
@@ -27,7 +28,13 @@ from services.cover_derivatives import (
     write_local_cover_derivatives,
 )
 from services.video.poster import VideoPosterService, video_poster_reference
-from utils.enums import AiTaskTypeEnum, TaskStatusEnum
+from utils.enums import (
+    AiTaskTypeEnum,
+    ImageModelTypeEnum,
+    TaskStatusEnum,
+    VideoGenerationModelTypeEnum,
+)
+from utils.image_protocol import ImageApiProtocol
 
 
 SENSITIVE_KEY_PARTS = (
@@ -56,6 +63,7 @@ CONTENT_TYPE_EXTENSIONS = {
     "video/quicktime": ".mov",
 }
 ALLOWED_MEDIA_EXTENSIONS = set(CONTENT_TYPE_EXTENSIONS.values())
+DEMO_MODEL_BASE_URL = "disabled://demo-model-catalog"
 
 
 def _hash_password(password: str) -> str:
@@ -79,6 +87,91 @@ def _delete_all(connection: sqlite3.Connection, tables: Iterable[str]) -> None:
     for table in tables:
         if table in existing:
             connection.execute(f'DELETE FROM "{table}"')
+
+
+def _insert_demo_supported_models(
+    connection: sqlite3.Connection,
+    now: str,
+) -> None:
+    """重建仅供查看的模型能力目录，不复制任何线上配置或密钥。
+
+    目录项保持 ``is_active``，让现有生图/视频选择器可以展示并切换能力参数；
+    演示账号仍是 viewer 且额度为零，所有生成接口由 RBAC 拒绝。即使权限边界
+    被错误放宽，空密钥与禁用协议地址也会使外部调用失败关闭。
+    """
+    if "ai_model_configs" not in _tables(connection):
+        return
+
+    image_protocols = {
+        ImageModelTypeEnum.gpt_image_2: ImageApiProtocol.openai_compatible.value,
+    }
+    video_protocols = {
+        VideoGenerationModelTypeEnum.minimax_h3: ImageApiProtocol.minimax.value,
+        VideoGenerationModelTypeEnum.wan_3: ImageApiProtocol.dashscope.value,
+    }
+    specs: list[dict[str, object]] = []
+    for model_type in ImageModelTypeEnum:
+        specs.append(
+            {
+                "task_type": AiTaskTypeEnum.reference_image.value,
+                "task_types": json.dumps([AiTaskTypeEnum.reference_image.value]),
+                "name": model_type.nickname,
+                "model": model_type.value,
+                "api_protocol": image_protocols.get(
+                    model_type,
+                    ImageApiProtocol.volcengine_ark.value,
+                ),
+                "image_model_type": model_type.value,
+                "video_model_type": None,
+            }
+        )
+    for model_type in VideoGenerationModelTypeEnum:
+        specs.append(
+            {
+                "task_type": AiTaskTypeEnum.video.value,
+                "task_types": json.dumps([AiTaskTypeEnum.video.value]),
+                "name": model_type.nickname,
+                "model": model_type.value,
+                "api_protocol": video_protocols.get(
+                    model_type,
+                    ImageApiProtocol.volcengine_ark.value,
+                ),
+                "image_model_type": None,
+                "video_model_type": model_type.value,
+            }
+        )
+
+    table_columns = {
+        str(row[1])
+        for row in connection.execute('PRAGMA table_info("ai_model_configs")')
+    }
+    common = {
+        "created_at": now,
+        "updated_at": now,
+        "base_url": DEMO_MODEL_BASE_URL,
+        "api_key": "",
+        "is_active": 1,
+        "concurrency": 1,
+        "supports_json_output": 0,
+        "max_context_characters": None,
+        "thinking": None,
+        "max_tokens": None,
+        "pricing": None,
+        "scope": "official",
+        "team_id": None,
+    }
+    required = {"task_type", "name", "api_key", "model", "is_active"}
+    if not required.issubset(table_columns):
+        raise RuntimeError("演示快照的 ai_model_configs 表结构不完整")
+    for spec in specs:
+        record = {**common, **spec}
+        columns = [column for column in record if column in table_columns]
+        placeholders = ",".join("?" for _ in columns)
+        quoted_columns = ",".join(f'"{column}"' for column in columns)
+        connection.execute(
+            f'INSERT INTO "ai_model_configs" ({quoted_columns}) VALUES ({placeholders})',
+            [record[column] for column in columns],
+        )
 
 
 def _retain_project_analysis_tasks(
@@ -249,6 +342,7 @@ def _prune_database(
 
     _delete_all(connection, ("team_members", "users", "teams"))
     now = datetime.now(timezone.utc).isoformat()
+    _insert_demo_supported_models(connection, now)
     connection.execute(
         """
         INSERT INTO users (

--- a/test/test_scripts/test_create_demo_snapshot.py
+++ b/test/test_scripts/test_create_demo_snapshot.py
@@ -6,10 +6,12 @@ import numpy as np
 import pytest
 
 from scripts.create_demo_snapshot import (
+    DEMO_MODEL_BASE_URL,
     _generate_video_posters,
     _rewrite_remote_references,
     create_snapshot,
 )
+from utils.enums import ImageModelTypeEnum, VideoGenerationModelTypeEnum
 
 
 SCHEMA = """
@@ -45,7 +47,14 @@ CREATE TABLE ai_tasks (
   status INT, request_params JSON, response_data JSON, error_message TEXT,
   stage TEXT, progress INT, started_at TEXT, finished_at TEXT
 );
-CREATE TABLE ai_model_configs (id INTEGER PRIMARY KEY, api_key TEXT);
+CREATE TABLE ai_model_configs (
+  id INTEGER PRIMARY KEY, created_at TEXT, updated_at TEXT, task_type INT,
+  task_types JSON, name TEXT, base_url TEXT, api_key TEXT, model TEXT,
+  api_protocol TEXT, image_model_type TEXT, video_model_type TEXT,
+  is_active INT, concurrency INT, supports_json_output INT,
+  max_context_characters INT, thinking TEXT, max_tokens INT, pricing JSON,
+  scope TEXT, team_id INT
+);
 CREATE TABLE user_sessions (id INTEGER PRIMARY KEY);
 CREATE TABLE team_invites (id INTEGER PRIMARY KEY);
 CREATE TABLE model_usage_records (id INTEGER PRIMARY KEY);
@@ -81,7 +90,9 @@ def _source_database(path: Path) -> None:
         connection.execute(
             "INSERT INTO team_members VALUES (9,'x','x','admin',1,5,NULL,9,9)"
         )
-        connection.execute("INSERT INTO ai_model_configs VALUES (1,'sk-private')")
+        connection.execute(
+            "INSERT INTO ai_model_configs (id,api_key) VALUES (1,'sk-private')"
+        )
         connection.execute(
             "INSERT INTO ai_tasks VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
             (
@@ -142,7 +153,22 @@ def test_snapshot_keeps_only_selected_projects_and_media(tmp_path: Path):
         assert connection.execute(
             "SELECT role,cost_limit FROM team_members"
         ).fetchone() == ("viewer", 0)
-        assert connection.execute("SELECT COUNT(*) FROM ai_model_configs").fetchone()[0] == 0
+        models = connection.execute(
+            """
+            SELECT name,base_url,api_key,is_active,image_model_type,video_model_type
+            FROM ai_model_configs ORDER BY id
+            """
+        ).fetchall()
+        assert len(models) == len(ImageModelTypeEnum) + len(VideoGenerationModelTypeEnum)
+        assert all(row[1] == DEMO_MODEL_BASE_URL for row in models)
+        assert all(row[2] == "" for row in models)
+        assert all(row[3] == 1 for row in models)
+        assert {row[4] for row in models if row[4]} == {
+            model_type.value for model_type in ImageModelTypeEnum
+        }
+        assert {row[5] for row in models if row[5]} == {
+            model_type.value for model_type in VideoGenerationModelTypeEnum
+        }
         task = connection.execute(
             "SELECT id,request_params,response_data FROM ai_tasks"
         ).fetchone()


### PR DESCRIPTION
## 变更内容

- 演示黄金快照重建 3 个生图与 6 个视频模型的只读能力目录
- 目录配置不复制真实模型配置，API Key 为空，服务地址为禁用协议
- 现有工作台下拉框可直接展示全部模型类型及其参数能力
- 修正演示快照 README 的模块运行命令

## 安全边界

- 演示账号仍为 viewer，团队余额和个人额度均为 0
- 创建、上传、编辑和生成接口继续由 RBAC 返回 403
- 不改商业站模型配置、数据库或运行逻辑

## 验证

- 后端：737 passed，112 skipped
- AUTH_ENABLED=true RBAC matrix passed
- 真实黄金快照：3 image + 6 video models
- 所有目录项均为空密钥、禁用地址
- 真实接口验证 viewer 写操作返回 403